### PR TITLE
Implement Sent Files page

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@ant-design/icons": "^6.0.0",
     "antd": "^5.26.2",
+    "date-fns": "^4.1.0",
     "file-saver": "^2.0.5",
     "firebase": "^11.9.1",
     "react": "^19.1.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -13,7 +13,10 @@ importers:
         version: 6.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       antd:
         specifier: ^5.26.2
-        version: 5.26.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 5.26.2(date-fns@4.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       file-saver:
         specifier: ^2.0.5
         version: 2.0.5
@@ -1225,6 +1228,9 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
@@ -3369,7 +3375,7 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
-  antd@5.26.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  antd@5.26.2(date-fns@4.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@ant-design/colors': 7.2.1
       '@ant-design/cssinjs': 1.23.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -3401,7 +3407,7 @@ snapshots:
       rc-motion: 2.9.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       rc-notification: 5.6.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       rc-pagination: 5.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      rc-picker: 4.11.3(dayjs@1.11.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      rc-picker: 4.11.3(date-fns@4.1.0)(dayjs@1.11.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       rc-progress: 4.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       rc-rate: 2.13.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       rc-resize-observer: 1.4.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -3513,6 +3519,8 @@ snapshots:
       which: 2.0.2
 
   csstype@3.1.3: {}
+
+  date-fns@4.1.0: {}
 
   dayjs@1.11.13: {}
 
@@ -4185,7 +4193,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  rc-picker@4.11.3(dayjs@1.11.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  rc-picker@4.11.3(date-fns@4.1.0)(dayjs@1.11.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@babel/runtime': 7.27.6
       '@rc-component/trigger': 2.2.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -4196,6 +4204,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
+      date-fns: 4.1.0
       dayjs: 1.11.13
 
   rc-progress@4.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):

--- a/web/src/components/SentFiles.tsx
+++ b/web/src/components/SentFiles.tsx
@@ -1,9 +1,68 @@
-import { Card } from 'antd';
+import React, { useEffect, useState } from 'react';
+import { List, Card, Button, Spin } from 'antd';
+import { db, auth } from '../lib/firebase';
+import { collection, query, orderBy, onSnapshot, deleteDoc, doc } from 'firebase/firestore';
+import { format } from 'date-fns';
 
 export function SentFiles() {
+  const [files, setFiles] = useState<Array<{ id: string; title: string; createdAt: Date }>>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const uid = auth.currentUser?.uid;
+    if (!uid) return;
+    const q = query(
+      collection(db, 'users', uid, 'sent'),
+      orderBy('createdAt', 'desc')
+    );
+    const unsub = onSnapshot(q, snap => {
+      const data = snap.docs.map(d => ({
+        id: d.id,
+        title: d.data().title,
+        createdAt: d.data().createdAt.toDate(),
+      }));
+      setFiles(data);
+      setLoading(false);
+    });
+    return () => unsub();
+  }, []);
+
+  const handleResend = async () => {
+    // Optional: re-trigger parseUpload or sharing logic
+  };
+
+  const handleDelete = async (id: string) => {
+    const uid = auth.currentUser?.uid;
+    if (!uid) return;
+    await deleteDoc(doc(db, 'users', uid, 'sent', id));
+  };
+
   return (
-    <Card title="Sent Files" style={{ margin: '2rem', borderRadius: '1.5rem' }}>
-      {/* TODO: list of sent YAML files */}
-    </Card>
+    <div style={{ padding: '2rem' }}>
+      <h1 style={{ fontSize: '2rem' }}>Sent Files</h1>
+      {loading ? (
+        <Spin size="large" />
+      ) : files.length === 0 ? (
+        <p>No sent files yet — send one from Validate page.</p>
+      ) : (
+        <List
+          grid={{ gutter: 16, column: 2 }}
+          dataSource={files}
+          renderItem={file => (
+            <List.Item key={file.id}>
+              <Card title={file.title}>
+                <p>Sent at: {format(file.createdAt, 'PPPpp')}</p>
+                <Button type="link" onClick={handleResend}>
+                  Resend
+                </Button>
+                <Button danger onClick={() => handleDelete(file.id)}>
+                  Delete
+                </Button>
+              </Card>
+            </List.Item>
+          )}
+        />
+      )}
+    </div>
   );
 }

--- a/web/src/components/UploadValidate.tsx
+++ b/web/src/components/UploadValidate.tsx
@@ -125,6 +125,13 @@ export function UploadValidate() {
         size: yaml.length,
         status: 'ready',
       });
+      await addDoc(collection(db, 'users', uid, 'sent'), {
+        title: filename,
+        yaml,
+        createdAt: serverTimestamp(),
+        size: yaml.length,
+        status: 'ready',
+      });
       message.success('Saved to My Files', 3);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- add Ant Design SentFiles page listing sent YAML uploads
- log sent files when saving validated YAML
- install `date-fns` for formatting

## Testing
- `pnpm lint`
- `pnpm run dev` *(fails to run fully: port busy output shown)*

------
https://chatgpt.com/codex/tasks/task_e_6861e02d1dcc8327bb0a9be6c57b3988