### PR TITLE
Fix account routing and firestore paths

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,7 +16,7 @@ import { Spin } from 'antd';
 function RequireAuth({ children }: { children: JSX.Element }) {
   const [user, loading] = useAuthState(auth);
   if (loading) return <Spin tip="Loading…" />;
-  return user ? children : <Navigate to="/" replace />;
+  return user ? children : <Navigate to="/signin" replace />;
 }
 
 
@@ -24,31 +24,31 @@ export function App() {
   return (
     <BrowserRouter>
       <nav className="p-4 space-x-4 glass-nav">
-        <Link to="/">Home</Link>
+        <Link to="/">Account</Link>
         <Link to="/parse">Validate XML</Link>
         <Link to="/files">My Files</Link>
         <Link to="/shared">Shared with Me</Link>
         <Link to="/sent">Sent Files</Link>
         <Link to="/contacts">Contacts</Link>
         <Link to="/devices">Link Phone</Link>
-        <Link to="/account">Account</Link>
       </nav>
       <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/parse" element={<UploadValidate />} />
-        <Route path="/files" element={<MyFiles />} />
-        <Route path="/shared" element={<SharedFiles />} />
-        <Route path="/sent" element={<SentFiles />} />
-        <Route path="/contacts" element={<Contacts />} />
-        <Route path="/devices" element={<Devices />} />
+        <Route path="/signin" element={<Home />} />
         <Route
-          path="/account"
+          path="/"
           element={
             <RequireAuth>
               <Account />
             </RequireAuth>
           }
         />
+        <Route path="/parse" element={<UploadValidate />} />
+        <Route path="/files" element={<MyFiles />} />
+        <Route path="/shared" element={<SharedFiles />} />
+        <Route path="/sent" element={<SentFiles />} />
+        <Route path="/contacts" element={<Contacts />} />
+        <Route path="/devices" element={<Devices />} />
+        <Route path="/account" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>
   );

--- a/web/src/components/Account.tsx
+++ b/web/src/components/Account.tsx
@@ -22,7 +22,7 @@ export function Account() {
 
   useEffect(() => {
     if (!uid) return;
-    const ref = doc(db, 'users', uid, 'profile');
+    const ref = doc(db, 'users', uid);
     const unsub = onSnapshot(
       ref,
       (snap) => {
@@ -51,7 +51,7 @@ export function Account() {
     if (!uid) return;
     setSaving(true);
     try {
-      await updateDoc(doc(db, 'users', uid, 'profile'), { ensembles });
+      await updateDoc(doc(db, 'users', uid), { ensembles });
       message.success('Saved');
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -80,12 +80,13 @@ export function Account() {
           <Avatar src={user.photoURL} size={64} />
           <div style={{ marginTop: 8, fontSize: '1.2rem' }}>{user.displayName}</div>
           <div>{user.email}</div>
-          {profile.lastSignedInAt && (
-            <div style={{ marginTop: 8 }}>
-              Last sign-in:{' '}
-              {profile.lastSignedInAt.toDate().toLocaleString()}
-            </div>
-          )}
+          {profile.lastSignedInAt &&
+            typeof (profile.lastSignedInAt as Timestamp).toDate === 'function' && (
+              <div style={{ marginTop: 8 }}>
+                Last sign-in:{' '}
+                {(profile.lastSignedInAt as Timestamp).toDate().toLocaleString()}
+              </div>
+            )}
         </Col>
         <Col span={24}>
           {user.providerData.map((p) => (

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -2,7 +2,7 @@ import { Card, Button, Row, Col, message } from 'antd';
 import { useNavigate } from 'react-router-dom';
 import { useAuthState } from 'react-firebase-hooks/auth';
 import { auth, signInWithGoogle, signInWithApple } from '../lib/firebase';
-import { type ReactElement } from 'react';
+import { type ReactElement, useEffect } from 'react';
 
 function GoogleIcon(): ReactElement {
   return (
@@ -50,15 +50,16 @@ export function Home() {
   const [user] = useAuthState(auth);
   const navigate = useNavigate();
 
-  if (user) {
-    navigate('/account');
-    return null;
-  }
+  useEffect(() => {
+    if (user) {
+      navigate('/', { replace: true });
+    }
+  }, [user, navigate]);
 
   const handle = async (fn: () => Promise<unknown>) => {
     try {
       await fn();
-      navigate('/account');
+      navigate('/', { replace: true });
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
       message.error(msg);

--- a/web/src/lib/firebase.ts
+++ b/web/src/lib/firebase.ts
@@ -49,7 +49,7 @@ const appleProvider = new OAuthProvider('apple.com');
 async function writeProfile(cred: UserCredential) {
   const u = cred.user;
   await setDoc(
-    doc(db, 'users', u.uid, 'profile'),
+    doc(db, 'users', u.uid),
     {
       displayName: u.displayName,
       email: u.email,


### PR DESCRIPTION
## Summary
- validate Firestore doc paths
- show last sign in only if timestamp has a `toDate` method
- redirect signed-in users away from sign-in page
- gate the root route with `RequireAuth`
- send `/account` traffic to `/`

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6861fc46f4d08327b25f665366c81e33