### PR TITLE
Lock down routing and add settings page

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,5 @@
 // web/src/App.tsx
-import { BrowserRouter, Routes, Route, Link, Navigate } from "react-router-dom";
-import type { JSX } from 'react';
+import { BrowserRouter, Routes, Route, Link, Navigate } from 'react-router-dom';
 import { Home } from './components/Home';
 import { UploadValidate } from './components/UploadValidate';
 import { MyFiles } from './components/MyFiles';
@@ -9,46 +8,94 @@ import { SentFiles } from './components/SentFiles';
 import { Contacts } from './components/Contacts';
 import { Devices } from './components/Devices';
 import { Account } from './components/Account';
+import Settings from './components/Settings';
 import { useAuthState } from 'react-firebase-hooks/auth';
 import { auth } from './lib/firebase';
-import { Spin } from 'antd';
-
-function RequireAuth({ children }: { children: JSX.Element }) {
-  const [user, loading] = useAuthState(auth);
-  if (loading) return <Spin tip="Loading…" />;
-  return user ? children : <Navigate to="/signin" replace />;
-}
-
+import { PrivateRoute } from './components/PrivateRoute';
 
 export function App() {
+  const [user] = useAuthState(auth);
   return (
     <BrowserRouter>
-      <nav className="p-4 space-x-4 glass-nav">
-        <Link to="/">Account</Link>
-        <Link to="/parse">Validate XML</Link>
-        <Link to="/files">My Files</Link>
-        <Link to="/shared">Shared with Me</Link>
-        <Link to="/sent">Sent Files</Link>
-        <Link to="/contacts">Contacts</Link>
-        <Link to="/devices">Link Phone</Link>
-      </nav>
+      {user && (
+        <nav className="p-4 space-x-4 glass-nav">
+          <Link to="/account">Account</Link>
+          <Link to="/settings">Settings</Link>
+          <Link to="/parse">Validate XML</Link>
+          <Link to="/files">My Files</Link>
+          <Link to="/shared">Shared with Me</Link>
+          <Link to="/sent">Sent Files</Link>
+          <Link to="/contacts">Contacts</Link>
+          <Link to="/devices">Link Phone</Link>
+        </nav>
+      )}
       <Routes>
-        <Route path="/signin" element={<Home />} />
+        <Route path="/" element={<Home />} />
         <Route
-          path="/"
+          path="/account"
           element={
-            <RequireAuth>
+            <PrivateRoute>
               <Account />
-            </RequireAuth>
+            </PrivateRoute>
           }
         />
-        <Route path="/parse" element={<UploadValidate />} />
-        <Route path="/files" element={<MyFiles />} />
-        <Route path="/shared" element={<SharedFiles />} />
-        <Route path="/sent" element={<SentFiles />} />
-        <Route path="/contacts" element={<Contacts />} />
-        <Route path="/devices" element={<Devices />} />
-        <Route path="/account" element={<Navigate to="/" replace />} />
+        <Route
+          path="/settings"
+          element={
+            <PrivateRoute>
+              <Settings />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/parse"
+          element={
+            <PrivateRoute>
+              <UploadValidate />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/files"
+          element={
+            <PrivateRoute>
+              <MyFiles />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/shared"
+          element={
+            <PrivateRoute>
+              <SharedFiles />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/sent"
+          element={
+            <PrivateRoute>
+              <SentFiles />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/contacts"
+          element={
+            <PrivateRoute>
+              <Contacts />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/devices"
+          element={
+            <PrivateRoute>
+              <Devices />
+            </PrivateRoute>
+          }
+        />
+        <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>
   );

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -52,14 +52,14 @@ export function Home() {
 
   useEffect(() => {
     if (user) {
-      navigate('/', { replace: true });
+      navigate('/account', { replace: true });
     }
   }, [user, navigate]);
 
   const handle = async (fn: () => Promise<unknown>) => {
     try {
       await fn();
-      navigate('/', { replace: true });
+      navigate('/account', { replace: true });
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
       message.error(msg);

--- a/web/src/components/PrivateRoute.tsx
+++ b/web/src/components/PrivateRoute.tsx
@@ -1,0 +1,11 @@
+import { Navigate } from 'react-router-dom';
+import { useAuthState } from 'react-firebase-hooks/auth';
+import { auth } from '../lib/firebase';
+import { Spin } from 'antd';
+import type { JSX } from 'react';
+
+export function PrivateRoute({ children }: { children: JSX.Element }) {
+  const [user, loading] = useAuthState(auth);
+  if (loading) return <Spin tip="Loading…" />;
+  return user ? children : <Navigate to="/" replace />;
+}

--- a/web/src/components/Settings.tsx
+++ b/web/src/components/Settings.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+import { Card, Tag, Input, Button, Spin, message } from 'antd';
+import { useAuthState } from 'react-firebase-hooks/auth';
+import { auth, db } from '../lib/firebase';
+import { doc, onSnapshot, updateDoc } from 'firebase/firestore';
+
+export default function Settings() {
+  const [user] = useAuthState(auth);
+  const uid = user?.uid;
+  const [ensembles, setEnsembles] = useState<string[]>([]);
+  const [newTag, setNewTag] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!uid) return;
+    const ref = doc(db, 'users', uid, 'profile');
+    const unsub = onSnapshot(
+      ref,
+      snap => {
+        const data = snap.exists() ? snap.data() as { ensembles?: string[] } : {};
+        setEnsembles(data.ensembles || []);
+        setLoading(false);
+      },
+      err => {
+        message.error(err.message);
+        setLoading(false);
+      }
+    );
+    return unsub;
+  }, [uid]);
+
+  const addTag = () => {
+    const t = newTag.trim();
+    if (t && !ensembles.includes(t)) setEnsembles([...ensembles, t]);
+    setNewTag('');
+  };
+
+  const removeTag = (t: string) => setEnsembles(ensembles.filter(e => e !== t));
+
+  const save = async () => {
+    if (!uid) return;
+    setSaving(true);
+    try {
+      await updateDoc(doc(db, 'users', uid, 'profile'), { ensembles });
+      message.success('Saved');
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      message.error(msg);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!uid || loading) return <Spin tip="Loading settings…" />;
+
+  return (
+    <Card title="Settings" className="glass-card" style={{ margin: '2rem', borderRadius: '1.5rem' }}>
+      {ensembles.map(t => (
+        <Tag key={t} closable onClose={() => removeTag(t)} style={{ marginBottom: 4 }}>
+          {t}
+        </Tag>
+      ))}
+      <Input
+        value={newTag}
+        onChange={e => setNewTag(e.target.value)}
+        onPressEnter={addTag}
+        placeholder="Add ensemble"
+        style={{ width: 200, marginRight: 8 }}
+      />
+      <Button onClick={addTag}>Add</Button>
+      <div style={{ marginTop: 8 }}>
+        <Button type="primary" onClick={save} loading={saving}>
+          Save Ensembles
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/web/src/lib/firebase.ts
+++ b/web/src/lib/firebase.ts
@@ -49,7 +49,7 @@ const appleProvider = new OAuthProvider('apple.com');
 async function writeProfile(cred: UserCredential) {
   const u = cred.user;
   await setDoc(
-    doc(db, 'users', u.uid),
+    doc(db, 'users', u.uid, 'profile'),
     {
       displayName: u.displayName,
       email: u.email,


### PR DESCRIPTION
## Summary
- redirect Home to `/account` after login
- show profile info only on Account page
- create Settings page with ensembles editor
- add PrivateRoute for auth-protected routes
- write profiles under `users/{uid}/profile`

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6861ff7653b08327b4432223c089d061