### PR TITLE
Simplify auth flow and route protection

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,20 +1,21 @@
 // web/src/App.tsx
 import { BrowserRouter, Routes, Route, Link, Navigate } from 'react-router-dom';
-import { Home } from './components/Home';
 import { UploadValidate } from './components/UploadValidate';
 import { MyFiles } from './components/MyFiles';
 import SharedFiles from './components/SharedFiles';
 import { SentFiles } from './components/SentFiles';
 import { Contacts } from './components/Contacts';
 import { Devices } from './components/Devices';
-import { Account } from './components/Account';
+import { Account } from './pages/Account';
 import Settings from './components/Settings';
 import { useAuthState } from 'react-firebase-hooks/auth';
 import { auth } from './lib/firebase';
-import { PrivateRoute } from './components/PrivateRoute';
+import { Spin } from 'antd';
 
 export function App() {
-  const [user] = useAuthState(auth);
+  const [user, loading] = useAuthState(auth);
+  if (loading) return <Spin />;
+
   return (
     <BrowserRouter>
       {user && (
@@ -30,72 +31,22 @@ export function App() {
         </nav>
       )}
       <Routes>
-        <Route path="/" element={<Home />} />
-        <Route
-          path="/account"
-          element={
-            <PrivateRoute>
-              <Account />
-            </PrivateRoute>
-          }
-        />
-        <Route
-          path="/settings"
-          element={
-            <PrivateRoute>
-              <Settings />
-            </PrivateRoute>
-          }
-        />
-        <Route
-          path="/parse"
-          element={
-            <PrivateRoute>
-              <UploadValidate />
-            </PrivateRoute>
-          }
-        />
-        <Route
-          path="/files"
-          element={
-            <PrivateRoute>
-              <MyFiles />
-            </PrivateRoute>
-          }
-        />
-        <Route
-          path="/shared"
-          element={
-            <PrivateRoute>
-              <SharedFiles />
-            </PrivateRoute>
-          }
-        />
-        <Route
-          path="/sent"
-          element={
-            <PrivateRoute>
-              <SentFiles />
-            </PrivateRoute>
-          }
-        />
-        <Route
-          path="/contacts"
-          element={
-            <PrivateRoute>
-              <Contacts />
-            </PrivateRoute>
-          }
-        />
-        <Route
-          path="/devices"
-          element={
-            <PrivateRoute>
-              <Devices />
-            </PrivateRoute>
-          }
-        />
-        <Route path="*" element={<Navigate to="/" replace />} />
+        <Route path="/account" element={<Account />} />
+        {!auth.currentUser ? (
+          <Route path="*" element={<Navigate to="/account" replace />} />
+        ) : (
+          <>
+            <Route path="/" element={<Navigate to="/parse" replace />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route path="/parse" element={<UploadValidate />} />
+            <Route path="/files" element={<MyFiles />} />
+            <Route path="/shared" element={<SharedFiles />} />
+            <Route path="/sent" element={<SentFiles />} />
+            <Route path="/contacts" element={<Contacts />} />
+            <Route path="/devices" element={<Devices />} />
+            <Route path="*" element={<Navigate to="/parse" replace />} />
+          </>
+        )}
       </Routes>
     </BrowserRouter>
   );

--- a/web/src/lib/firebase.ts
+++ b/web/src/lib/firebase.ts
@@ -43,8 +43,8 @@ if (import.meta.env.DEV) {
   connectFirestoreEmulator(db, "127.0.0.1", 8080);
 }
 
-const googleProvider = new GoogleAuthProvider();
-const appleProvider = new OAuthProvider('apple.com');
+export const googleProvider = new GoogleAuthProvider();
+export const appleProvider = new OAuthProvider('apple.com');
 
 async function writeProfile(cred: UserCredential) {
   const u = cred.user;

--- a/web/src/pages/Account.tsx
+++ b/web/src/pages/Account.tsx
@@ -1,0 +1,43 @@
+import { Button, Card, Col, Row, message } from 'antd';
+import { useNavigate } from 'react-router-dom';
+import { useAuthState } from 'react-firebase-hooks/auth';
+import { auth, signInWithGoogle, signInWithApple } from '../lib/firebase';
+import { useEffect } from 'react';
+
+export function Account() {
+  const [user] = useAuthState(auth);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (user) {
+      navigate('/parse', { replace: true });
+    }
+  }, [user, navigate]);
+
+  const handle = async (fn: () => Promise<unknown>) => {
+    try {
+      await fn();
+      navigate('/parse', { replace: true });
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      message.error(msg);
+    }
+  };
+
+  return (
+    <Card className="glass-card" style={{ margin: '2rem', borderRadius: '1.5rem' }}>
+      <Row gutter={[16, 16]} justify="center">
+        <Col span={24}>
+          <Button type="primary" size="large" block onClick={() => handle(signInWithGoogle)}>
+            Sign in with Google
+          </Button>
+        </Col>
+        <Col span={24}>
+          <Button size="large" block onClick={() => handle(signInWithApple)}>
+            Sign in with Apple
+          </Button>
+        </Col>
+      </Row>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- create Account OAuth landing page with two buttons
- export google and apple auth providers from firebase
- protect all routes except `/account` and redirect to `/parse` once signed in

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6862052a1c2c8327af7a95f4c77d1e91