### PR TITLE
Add Firebase auth login screen

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,9 +11,9 @@ import Settings from './components/Settings';
 import { useAuthState } from 'react-firebase-hooks/auth';
 import { auth } from './lib/firebase';
 import { Spin } from 'antd';
-import { type ReactElement } from 'react';
+import type { JSX } from 'react';
 
-function RequireAuth({ children }: { children: ReactElement }) {
+function RequireAuth({ children }: { children: JSX.Element }) {
   return auth.currentUser ? children : <Navigate to="/account" replace />;
 }
 

--- a/web/src/lib/firebase.ts
+++ b/web/src/lib/firebase.ts
@@ -1,5 +1,5 @@
 // web/src/lib/firebase.ts
-import { initializeApp } from "firebase/app";
+import { initializeApp } from 'firebase/app';
 import {
   getAuth,
   connectAuthEmulator,
@@ -8,20 +8,20 @@ import {
   signInWithPopup,
   unlink,
   type Auth,
-} from "firebase/auth";
+} from 'firebase/auth';
 import {
   getFirestore,
   connectFirestoreEmulator,
-  Firestore,
-} from "firebase/firestore";
+  type Firestore,
+} from 'firebase/firestore';
 
-const firebaseConfig = {
+const config = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
   authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
   projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
 };
 
-const app = initializeApp(firebaseConfig);
+const app = initializeApp(config);
 
 // — Auth setup —
 export const auth: Auth = getAuth(app);

--- a/web/src/pages/Account.tsx
+++ b/web/src/pages/Account.tsx
@@ -1,37 +1,38 @@
-import { Button, message } from 'antd';
+import { Button, Row, Col, message } from 'antd';
+import { signInWithGoogle, signInWithApple } from '../lib/firebase';
 import { useNavigate } from 'react-router-dom';
-import { useAuthState } from 'react-firebase-hooks/auth';
-import { auth, signInWithGoogle, signInWithApple } from '../lib/firebase';
-import { useEffect } from 'react';
 
 export function Account() {
-  const [user] = useAuthState(auth);
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if (user) {
-      navigate('/parse', { replace: true });
-    }
-  }, [user, navigate]);
-
-  const handle = async (fn: () => Promise<unknown>) => {
+  const nav = useNavigate();
+  const handleSignIn = async (providerFn: () => Promise<unknown>) => {
     try {
-      await fn();
-      navigate('/parse', { replace: true });
+      await providerFn();
+      nav('/parse');
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      message.error(msg);
+      const err = e instanceof Error ? e.message : 'Authentication failed';
+      message.error(err);
     }
   };
 
   return (
-    <div style={{ maxWidth: 320, margin: '2rem auto', display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-      <Button type="primary" block onClick={() => handle(signInWithGoogle)}>
-        Sign in with Google
-      </Button>
-      <Button block onClick={() => handle(signInWithApple)}>
-        Sign in with Apple
-      </Button>
-    </div>
+    <Row justify="center" align="middle" style={{ height: '100vh' }}>
+      <Col>
+        <Button
+          block
+          size="large"
+          style={{ marginBottom: '1rem' }}
+          onClick={() => handleSignIn(signInWithGoogle)}
+        >
+          Sign in with Google
+        </Button>
+        <Button
+          block
+          size="large"
+          onClick={() => handleSignIn(signInWithApple)}
+        >
+          Sign in with Apple
+        </Button>
+      </Col>
+    </Row>
   );
 }


### PR DESCRIPTION
## Summary
- replace old account page with simple Firebase auth buttons
- export Google and Apple sign-in helpers
- guard routes with `<RequireAuth>`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68620975d8dc8327bf0c6224a53d7aae