### PR TITLE
Add auth tabs for sign‑in and sign‑up

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -8,6 +8,9 @@ service cloud.firestore {
     match /users/{uid}/linkTokens/{tokenId} {
       allow read, write: if request.auth != null && request.auth.uid == uid;
     }
+    match /users/{uid} {
+      allow read, write: if request.auth != null && request.auth.uid == uid;
+    }
     match /{document=**} {
       // This rule allows anyone with your database reference to view, edit,
       // and delete all data in your database. It is useful for getting

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,7 +6,8 @@ import SharedFiles from './components/SharedFiles';
 import { SentFiles } from './components/SentFiles';
 import { Contacts } from './components/Contacts';
 import { Devices } from './components/Devices';
-import { Account } from './pages/Account';
+import { Account } from './components/Account';
+import { AuthPage } from './components/AuthPage';
 import Settings from './components/Settings';
 import { useAuthState } from 'react-firebase-hooks/auth';
 import { auth } from './lib/firebase';
@@ -14,7 +15,11 @@ import { Spin } from 'antd';
 import type { JSX } from 'react';
 
 function RequireAuth({ children }: { children: JSX.Element }) {
-  return auth.currentUser ? children : <Navigate to="/account" replace />;
+  return auth.currentUser ? children : <Navigate to="/" replace />;
+}
+
+function RequireNoAuth({ children }: { children: JSX.Element }) {
+  return auth.currentUser ? <Navigate to="/parse" replace /> : children;
 }
 
 export function App() {
@@ -36,8 +41,8 @@ export function App() {
         </nav>
       )}
       <Routes>
-        <Route path="/account" element={<Account />} />
-        <Route path="/" element={<RequireAuth><Navigate to="/parse" replace /></RequireAuth>} />
+        <Route path="/account" element={<RequireAuth><Account /></RequireAuth>} />
+        <Route path="/" element={<RequireNoAuth><AuthPage /></RequireNoAuth>} />
         <Route path="/settings" element={<RequireAuth><Settings /></RequireAuth>} />
         <Route path="/parse" element={<RequireAuth><UploadValidate /></RequireAuth>} />
         <Route path="/files" element={<RequireAuth><MyFiles /></RequireAuth>} />

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -4,6 +4,9 @@ import {
   signInWithEmailAndPassword,
   updateProfile,
   sendPasswordResetEmail,
+  browserLocalPersistence,
+  browserSessionPersistence,
+  setPersistence,
 } from 'firebase/auth';
 import {
   collection,
@@ -32,7 +35,11 @@ export async function createAccount(
   return cred.user;
 }
 
-export async function signInWithIdentifier(identifier: string, password: string) {
+export async function signInWithIdentifier(
+  identifier: string,
+  password: string,
+  remember = true,
+) {
   let email = identifier;
   if (!identifier.includes('@')) {
     const q = query(collection(db, 'users'), where('handle', '==', identifier.toLowerCase()));
@@ -40,6 +47,10 @@ export async function signInWithIdentifier(identifier: string, password: string)
     if (snap.empty) throw new Error('User not found');
     email = (snap.docs[0].data() as { email: string }).email;
   }
+  await setPersistence(
+    auth,
+    remember ? browserLocalPersistence : browserSessionPersistence
+  );
   const cred = await signInWithEmailAndPassword(auth, email, password);
   return cred.user;
 }

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,0 +1,47 @@
+import { auth, db } from './firebase';
+import {
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+  updateProfile,
+  sendPasswordResetEmail,
+} from 'firebase/auth';
+import {
+  collection,
+  query,
+  where,
+  getDocs,
+  doc,
+  setDoc,
+  serverTimestamp,
+} from 'firebase/firestore';
+
+export async function createAccount(
+  email: string,
+  password: string,
+  handle: string,
+  name: string
+) {
+  const cred = await createUserWithEmailAndPassword(auth, email, password);
+  if (name) await updateProfile(cred.user, { displayName: name });
+  await setDoc(doc(db, 'users', cred.user.uid), {
+    email,
+    handle,
+    name,
+    createdAt: serverTimestamp(),
+  });
+  return cred.user;
+}
+
+export async function signInWithIdentifier(identifier: string, password: string) {
+  let email = identifier;
+  if (!identifier.includes('@')) {
+    const q = query(collection(db, 'users'), where('handle', '==', identifier.toLowerCase()));
+    const snap = await getDocs(q);
+    if (snap.empty) throw new Error('User not found');
+    email = (snap.docs[0].data() as { email: string }).email;
+  }
+  const cred = await signInWithEmailAndPassword(auth, email, password);
+  return cred.user;
+}
+
+export { sendPasswordResetEmail };


### PR DESCRIPTION
## Summary
- implement email auth helpers
- add AuthPage with sign in / create account tabs
- wire AuthPage on landing route
- secure user documents in firestore rules

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68620cd964c08327b01e463d4941dbc4