### PR TITLE
Add Firebase auth UI

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,8 +6,7 @@ import SharedFiles from './components/SharedFiles';
 import { SentFiles } from './components/SentFiles';
 import { Contacts } from './components/Contacts';
 import { Devices } from './components/Devices';
-import { Account } from './components/Account';
-import { AuthPage } from './components/AuthPage';
+import { Account } from './pages/Account';
 import Settings from './components/Settings';
 import { useAuthState } from 'react-firebase-hooks/auth';
 import { auth } from './lib/firebase';
@@ -41,8 +40,8 @@ export function App() {
         </nav>
       )}
       <Routes>
-        <Route path="/account" element={<RequireAuth><Account /></RequireAuth>} />
-        <Route path="/" element={<RequireNoAuth><AuthPage /></RequireNoAuth>} />
+        <Route path="/account" element={<RequireNoAuth><Account /></RequireNoAuth>} />
+        <Route path="/" element={<Navigate to="/account" replace />} />
         <Route path="/settings" element={<RequireAuth><Settings /></RequireAuth>} />
         <Route path="/parse" element={<RequireAuth><UploadValidate /></RequireAuth>} />
         <Route path="/files" element={<RequireAuth><MyFiles /></RequireAuth>} />

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -24,12 +24,19 @@ export async function createAccount(
   handle: string,
   name: string
 ) {
+  const h = handle.toLowerCase();
+  const existing = await getDocs(
+    query(collection(db, 'users'), where('handle', '==', h))
+  );
+  if (!existing.empty) {
+    throw new Error('Handle already taken');
+  }
   const cred = await createUserWithEmailAndPassword(auth, email, password);
   if (name) await updateProfile(cred.user, { displayName: name });
   await setDoc(doc(db, 'users', cred.user.uid), {
     email,
-    handle,
-    name,
+    handle: h,
+    name: name || null,
     createdAt: serverTimestamp(),
   });
   return cred.user;

--- a/web/src/pages/Account.tsx
+++ b/web/src/pages/Account.tsx
@@ -1,38 +1,219 @@
-import { Button, Row, Col, message } from 'antd';
-import { signInWithGoogle, signInWithApple } from '../lib/firebase';
+import { useState, useEffect } from 'react';
+import {
+  Form,
+  Input,
+  Button,
+  Checkbox,
+  Tabs,
+  Row,
+  Col,
+  Card,
+  ConfigProvider,
+  Switch,
+  Modal,
+  message,
+} from 'antd';
+import { SunOutlined, MoonOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
+import {
+  createAccount,
+  signInWithIdentifier,
+  sendPasswordResetEmail,
+} from '../lib/auth';
+import { db, auth } from '../lib/firebase';
+import { collection, query, where, getDocs } from 'firebase/firestore';
 
 export function Account() {
-  const nav = useNavigate();
-  const handleSignIn = async (providerFn: () => Promise<unknown>) => {
+  const [dark, setDark] = useState(() => localStorage.getItem('theme') === 'dark');
+  useEffect(() => {
+    document.body.dataset.theme = dark ? 'dark' : 'light';
+    localStorage.setItem('theme', dark ? 'dark' : 'light');
+  }, [dark]);
+
+  const navigate = useNavigate();
+  const [signInForm] = Form.useForm();
+  const [createForm] = Form.useForm();
+  const [forgotForm] = Form.useForm();
+  const [loadingSignIn, setLoadingSignIn] = useState(false);
+  const [loadingCreate, setLoadingCreate] = useState(false);
+  const [forgotOpen, setForgotOpen] = useState(false);
+  const [forgotLoading, setForgotLoading] = useState(false);
+
+  const validateHandle = async (_: unknown, value: string) => {
+    if (!value) return Promise.reject('Username is required');
+    if (!/^[a-z0-9_]{1,32}$/.test(value)) {
+      return Promise.reject('Use a-z, 0-9 or _ (max 32)');
+    }
+    const snap = await getDocs(
+      query(collection(db, 'users'), where('handle', '==', value.toLowerCase()))
+    );
+    if (!snap.empty) return Promise.reject('Username already taken');
+    return Promise.resolve();
+  };
+
+  const passwordRule = {
+    validator(_: unknown, value: string) {
+      if (!value) return Promise.reject('Password is required');
+      const re = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{}|;:'",.<>/?])[ -~]{12,}$/;
+      return re.test(value)
+        ? Promise.resolve()
+        : Promise.reject('Min 12 chars with letters, numbers & symbol');
+    },
+  };
+
+  const onSignIn = async (vals: any) => {
+    setLoadingSignIn(true);
     try {
-      await providerFn();
-      nav('/parse');
-    } catch (e: unknown) {
-      const err = e instanceof Error ? e.message : 'Authentication failed';
-      message.error(err);
+      await signInWithIdentifier(vals.identifier, vals.password, vals.remember);
+      navigate('/parse');
+    } catch (e: any) {
+      message.error(e.message || 'Sign in failed');
+    } finally {
+      setLoadingSignIn(false);
+    }
+  };
+
+  const onCreate = async (vals: any) => {
+    if (vals.password !== vals.confirm) {
+      message.error('Passwords do not match');
+      return;
+    }
+    setLoadingCreate(true);
+    try {
+      await createAccount(
+        vals.email,
+        vals.password,
+        vals.handle.toLowerCase(),
+        vals.name || ''
+      );
+      navigate('/parse');
+    } catch (e: any) {
+      message.error(e.message || 'Account creation failed');
+    } finally {
+      setLoadingCreate(false);
+    }
+  };
+
+  const handleForgot = async () => {
+    try {
+      const id = forgotForm.getFieldValue('identifier');
+      if (!id) {
+        message.error('Please enter your email or handle');
+        return;
+      }
+      setForgotLoading(true);
+      let email = id as string;
+      if (!id.includes('@')) {
+        const snap = await getDocs(
+          query(collection(db, 'users'), where('handle', '==', id.toLowerCase()))
+        );
+        if (snap.empty) {
+          message.error('User not found');
+          setForgotLoading(false);
+          return;
+        }
+        email = (snap.docs[0].data() as { email: string }).email;
+      }
+      await sendPasswordResetEmail(auth, email);
+      message.success('Password reset sent');
+      setForgotOpen(false);
+      forgotForm.resetFields();
+    } catch (e: any) {
+      message.error(e.message || 'Failed to send reset email');
+    } finally {
+      setForgotLoading(false);
     }
   };
 
   return (
-    <Row justify="center" align="middle" style={{ height: '100vh' }}>
-      <Col>
-        <Button
-          block
-          size="large"
-          style={{ marginBottom: '1rem' }}
-          onClick={() => handleSignIn(signInWithGoogle)}
-        >
-          Sign in with Google
-        </Button>
-        <Button
-          block
-          size="large"
-          onClick={() => handleSignIn(signInWithApple)}
-        >
-          Sign in with Apple
-        </Button>
-      </Col>
-    </Row>
+    <ConfigProvider theme={{ token: { colorPrimary: '#70C73C', fontFamily: 'system-ui' } }}>
+      <Row justify="center" align="middle" style={{ minHeight: '100vh' }}>
+        <Col xs={23} sm={16} md={12} lg={8}>
+          <Card className="glass-card">
+            <Row justify="space-between" align="middle" style={{ marginBottom: '1rem' }}>
+              <h1 style={{ margin: 0 }}>SyncTimer</h1>
+              <Switch
+                checkedChildren={<MoonOutlined />}
+                unCheckedChildren={<SunOutlined />}
+                checked={dark}
+                onChange={setDark}
+              />
+            </Row>
+            <Tabs
+              items={[
+                {
+                  key: 'signin',
+                  label: 'Sign In',
+                  children: (
+                    <Form form={signInForm} layout="vertical" onFinish={onSignIn} initialValues={{ remember: true }}>
+                      <Form.Item name="identifier" label="Username or Email" rules={[{ required: true }]}> <Input /> </Form.Item>
+                      <Form.Item name="password" label="Password" rules={[{ required: true }]}> <Input.Password /> </Form.Item>
+                      <Form.Item name="remember" valuePropName="checked"> <Checkbox>Remember me</Checkbox> </Form.Item>
+                      <Form.Item>
+                        <Button type="link" onClick={() => setForgotOpen(true)} style={{ padding: 0 }}>
+                          Forgot password?
+                        </Button>
+                      </Form.Item>
+                      <Form.Item>
+                        <Button type="primary" htmlType="submit" block loading={loadingSignIn} disabled={loadingSignIn}>
+                          Sign In
+                        </Button>
+                      </Form.Item>
+                    </Form>
+                  ),
+                },
+                {
+                  key: 'create',
+                  label: 'Create Account',
+                  children: (
+                    <Form form={createForm} layout="vertical" onFinish={onCreate}>
+                      <Form.Item name="email" label="Email" rules={[{ required: true, type: 'email' }]}> <Input /> </Form.Item>
+                      <Form.Item name="handle" label="Username" rules={[{ validator: validateHandle }]} validateTrigger="onBlur"> <Input /> </Form.Item>
+                      <Form.Item name="name" label="Full name"> <Input /> </Form.Item>
+                      <Form.Item name="password" label="Password" rules={[passwordRule]}> <Input.Password /> </Form.Item>
+                      <Form.Item
+                        name="confirm"
+                        label="Confirm Password"
+                        dependencies={["password"]}
+                        rules={[
+                          { required: true },
+                          ({ getFieldValue }) => ({
+                            validator(_, value) {
+                              if (!value || getFieldValue('password') === value) {
+                                return Promise.resolve();
+                              }
+                              return Promise.reject(new Error('Passwords do not match'));
+                            },
+                          }),
+                        ]}
+                      >
+                        <Input.Password />
+                      </Form.Item>
+                      <Form.Item>
+                        <Button type="primary" htmlType="submit" block loading={loadingCreate} disabled={loadingCreate}>
+                          Create Account
+                        </Button>
+                      </Form.Item>
+                    </Form>
+                  ),
+                },
+              ]}
+            />
+          </Card>
+        </Col>
+      </Row>
+      <Modal
+        open={forgotOpen}
+        title="Reset Password"
+        onCancel={() => setForgotOpen(false)}
+        onOk={handleForgot}
+        okText="Send Reset"
+        confirmLoading={forgotLoading}
+      >
+        <Form form={forgotForm} layout="vertical">
+          <Form.Item name="identifier" label="Email or Handle" rules={[{ required: true }]}> <Input /> </Form.Item>
+        </Form>
+      </Modal>
+    </ConfigProvider>
   );
 }


### PR DESCRIPTION
## Summary
- implement email/password auth UI at `/account`
- enforce unique handles in `createAccount`
- update routing so `/account` is the entry page

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686210575d688327bdbc0b80c7249a28