### PR TITLE
Implement Account Settings screen

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,7 @@
     "firebase": "^11.9.1",
     "qrcode.react": "^4.2.0",
     "react": "^19.1.0",
+    "react-avatar-editor": "^13.0.0",
     "react-dom": "^19.1.0",
     "react-dropzone": "^14.3.8",
     "react-firebase-hooks": "^5.1.1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       react:
         specifier: ^19.1.0
         version: 19.1.0
+      react-avatar-editor:
+        specifier: ^13.0.0
+        version: 13.0.2(@babel/core@7.27.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
@@ -184,6 +187,11 @@ packages:
     resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-define-polyfill-provider@0.6.5':
+    resolution: {integrity: sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==}
+    peerDependencies:
+      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
   '@babel/helper-module-imports@7.27.1':
     resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
     engines: {node: '>=6.9.0'}
@@ -227,6 +235,12 @@ packages:
 
   '@babel/plugin-transform-react-jsx-source@7.27.1':
     resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-runtime@7.27.4':
+    resolution: {integrity: sha512-D68nR5zxU64EUzV8i7T3R5XP0Xhrou/amNnddsRQssx6GrTLdZl1rLxyjtVZBd+v/NVX4AbTPOB5aU8thAZV1A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1165,6 +1179,21 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  babel-plugin-polyfill-corejs2@0.4.14:
+    resolution: {integrity: sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==}
+    peerDependencies:
+      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  babel-plugin-polyfill-corejs3@0.11.1:
+    resolution: {integrity: sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==}
+    peerDependencies:
+      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  babel-plugin-polyfill-regenerator@0.6.5:
+    resolution: {integrity: sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==}
+    peerDependencies:
+      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -1235,6 +1264,9 @@ packages:
 
   copy-to-clipboard@3.3.3:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
+
+  core-js-compat@3.43.0:
+    resolution: {integrity: sha512-2GML2ZsCc5LR7hZYz4AXmjQw8zuy2T//2QntwdnpuYI7jteT6GVYJL7F6C2C57R7gSYrcqVW3lAALefdbhBLDA==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1416,6 +1448,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -1453,6 +1488,10 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
 
   hast-util-parse-selector@2.2.5:
     resolution: {integrity: sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==}
@@ -1493,6 +1532,10 @@ packages:
 
   is-alphanumerical@1.0.4:
     resolution: {integrity: sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==}
+
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
 
   is-decimal@1.0.4:
     resolution: {integrity: sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==}
@@ -1630,6 +1673,9 @@ packages:
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
+  lodash.debounce@4.0.8:
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -1725,6 +1771,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2006,6 +2055,12 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
+  react-avatar-editor@13.0.2:
+    resolution: {integrity: sha512-a4ajbi7lwDh98kgEtSEeKMu0vs0CHTczkq4Xcxr1EiwMFH1GlgHCEtwGU8q/H5W8SeLnH4KPK8LUjEEaZXklxQ==}
+    peerDependencies:
+      react: ^0.14.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^0.14.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+
   react-dom@19.1.0:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
@@ -2075,6 +2130,11 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve@1.22.10:
+    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -2141,6 +2201,10 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   tailwindcss@4.1.11:
     resolution: {integrity: sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==}
@@ -2413,6 +2477,17 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.27.7)':
+    dependencies:
+      '@babel/core': 7.27.7
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-plugin-utils': 7.27.1
+      debug: 4.4.1
+      lodash.debounce: 4.0.8
+      resolve: 1.22.10
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-imports@7.27.1':
     dependencies:
       '@babel/traverse': 7.27.7
@@ -2455,6 +2530,18 @@ snapshots:
     dependencies:
       '@babel/core': 7.27.7
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-runtime@7.27.4(@babel/core@7.27.7)':
+    dependencies:
+      '@babel/core': 7.27.7
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-plugin-utils': 7.27.1
+      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.27.7)
+      babel-plugin-polyfill-corejs3: 0.11.1(@babel/core@7.27.7)
+      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.27.7)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/runtime@7.27.6': {}
 
@@ -3479,6 +3566,30 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.27.7):
+    dependencies:
+      '@babel/compat-data': 7.27.7
+      '@babel/core': 7.27.7
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.27.7)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-corejs3@0.11.1(@babel/core@7.27.7):
+    dependencies:
+      '@babel/core': 7.27.7
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.27.7)
+      core-js-compat: 3.43.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.27.7):
+    dependencies:
+      '@babel/core': 7.27.7
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.27.7)
+    transitivePeerDependencies:
+      - supports-color
+
   balanced-match@1.0.2: {}
 
   brace-expansion@1.1.12:
@@ -3543,6 +3654,10 @@ snapshots:
   copy-to-clipboard@3.3.3:
     dependencies:
       toggle-selection: 1.0.6
+
+  core-js-compat@3.43.0:
+    dependencies:
+      browserslist: 4.25.1
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3783,6 +3898,8 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
@@ -3806,6 +3923,10 @@ snapshots:
   graphemer@1.4.0: {}
 
   has-flag@4.0.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
 
   hast-util-parse-selector@2.2.5: {}
 
@@ -3842,6 +3963,10 @@ snapshots:
     dependencies:
       is-alphabetical: 1.0.4
       is-decimal: 1.0.4
+
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
 
   is-decimal@1.0.4: {}
 
@@ -3941,6 +4066,8 @@ snapshots:
 
   lodash.camelcase@4.3.0: {}
 
+  lodash.debounce@4.0.8: {}
+
   lodash.merge@4.6.2: {}
 
   long@5.3.2: {}
@@ -4030,6 +4157,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-parse@1.0.7: {}
 
   picocolors@1.1.1: {}
 
@@ -4404,6 +4533,17 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
+  react-avatar-editor@13.0.2(@babel/core@7.27.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@babel/plugin-transform-runtime': 7.27.4(@babel/core@7.27.7)
+      '@babel/runtime': 7.27.6
+      prop-types: 15.8.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
   react-dom@19.1.0(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -4471,6 +4611,12 @@ snapshots:
   resize-observer-polyfill@1.5.1: {}
 
   resolve-from@4.0.0: {}
+
+  resolve@1.22.10:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
 
@@ -4545,6 +4691,8 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   tailwindcss@4.1.11: {}
 

--- a/web/src/components/Account.tsx
+++ b/web/src/components/Account.tsx
@@ -1,65 +1,303 @@
-import { useEffect, useState } from 'react';
-import { Card, Avatar, Button, Spin, Row, Col, message } from 'antd';
+import { useEffect, useRef, useState } from 'react';
+import {
+  Card,
+  Avatar,
+  Button,
+  Spin,
+  Row,
+  Col,
+  Form,
+  Input,
+  Upload,
+  Modal,
+  Collapse,
+  message,
+  Progress,
+} from 'antd';
+import { UploadOutlined } from '@ant-design/icons';
 import { useAuthState } from 'react-firebase-hooks/auth';
 import { auth, db } from '../lib/firebase';
-import { signOut } from 'firebase/auth';
-import { doc, onSnapshot, type Timestamp } from 'firebase/firestore';
+import {
+  updateProfile,
+  updateEmail,
+  updatePassword,
+  EmailAuthProvider,
+  reauthenticateWithCredential,
+  deleteUser,
+} from 'firebase/auth';
+import {
+  doc,
+  onSnapshot,
+  setDoc,
+  getDoc,
+  getDocs,
+  query,
+  where,
+  collectionGroup,
+  deleteDoc,
+  type Timestamp,
+} from 'firebase/firestore';
+import {
+  getStorage,
+  ref as storageRef,
+  uploadBytes,
+  getDownloadURL,
+  deleteObject,
+} from 'firebase/storage';
+import AvatarEditor from 'react-avatar-editor';
+import { saveAs } from 'file-saver';
 
 interface Profile {
   displayName?: string;
   email?: string;
   photoURL?: string;
+  bio?: string;
+  pronouns?: string;
+  username?: string;
   lastSignedInAt?: Timestamp;
 }
 
 export function Account() {
   const [user] = useAuthState(auth);
   const uid = user?.uid;
+  const profileRef = uid ? doc(db, 'users', uid, 'profile', 'main') : null;
   const [profile, setProfile] = useState<Profile | null>(null);
+  const [form] = Form.useForm();
+  const [pwForm] = Form.useForm();
+  const editorRef = useRef<any>(null);
+  const [photoModal, setPhotoModal] = useState(false);
+  const [photoFile, setPhotoFile] = useState<File | null>(null);
+  const [pwOpen, setPwOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [pwSaving, setPwSaving] = useState(false);
 
   useEffect(() => {
-    if (!uid) return;
-    const ref = doc(db, 'users', uid);
+    if (!profileRef) return;
     const unsub = onSnapshot(
-      ref,
+      profileRef,
       (snap) => {
-        const data = (snap.exists() ? (snap.data() as Profile) : {}) as Profile;
+        const data = snap.exists() ? ((snap.data() as Profile) || {}) : {};
         setProfile(data);
       },
       (err) => message.error(err.message)
     );
     return unsub;
-  }, [uid]);
+  }, [profileRef]);
+
+  useEffect(() => {
+    if (!profile || !user) return;
+    form.setFieldsValue({
+      displayName: profile.displayName || user.displayName || '',
+      bio: profile.bio || '',
+      pronouns: profile.pronouns || '',
+      username: profile.username || '',
+      email: profile.email || user.email || '',
+    });
+  }, [profile, user, form]);
 
 
   if (!user || !profile) return <Spin />;
 
+  const beforeUpload = (file: File) => {
+    setPhotoFile(file);
+    setPhotoModal(true);
+    return false;
+  };
+
+  const uploadPhoto = async () => {
+    if (!uid || !photoFile || !editorRef.current) return;
+    const canvas = editorRef.current.getImageScaledToCanvas();
+    canvas.toBlob(async (blob: Blob | null) => {
+      if (!blob) return;
+      try {
+        const storage = getStorage();
+        const ref = storageRef(storage, `avatars/${uid}.png`);
+        await uploadBytes(ref, blob);
+        const url = await getDownloadURL(ref);
+        await Promise.all([
+          updateProfile(auth.currentUser!, { photoURL: url }),
+          profileRef ? setDoc(profileRef, { photoURL: url }, { merge: true }) : Promise.resolve(),
+        ]);
+        message.success('Photo updated');
+        setPhotoModal(false);
+        setPhotoFile(null);
+      } catch (e: any) {
+        message.error(e.message);
+      }
+    }, 'image/png');
+  };
+
+  const checkUsername = async (_: unknown, value: string) => {
+    if (!value) return Promise.reject('Username is required');
+    if (!/^[a-z0-9]{1,32}$/.test(value)) {
+      return Promise.reject('Use 1-32 lowercase letters or numbers');
+    }
+    const snap = await getDocs(
+      query(collectionGroup(db, 'profile'), where('username', '==', value))
+    );
+    const taken = snap.docs.find((d) => d.ref.parent.parent?.id !== uid);
+    if (taken) {
+      return Promise.reject('Username already taken');
+    }
+    return Promise.resolve();
+  };
+
+  const saveProfile = async (vals: any) => {
+    if (!uid) return;
+    setSaving(true);
+    try {
+      if (vals.email && vals.email !== user.email) {
+        await updateEmail(auth.currentUser!, vals.email);
+      }
+      if (vals.displayName !== user.displayName) {
+        await updateProfile(auth.currentUser!, { displayName: vals.displayName });
+      }
+      if (profileRef) {
+        await setDoc(
+          profileRef,
+          {
+            displayName: vals.displayName,
+            bio: vals.bio || '',
+            pronouns: vals.pronouns || '',
+            username: vals.username,
+            email: vals.email,
+          },
+          { merge: true }
+        );
+      }
+      message.success('Profile updated');
+    } catch (e: any) {
+      message.error(e.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const strength = (pw: string) => {
+    let score = 0;
+    if (pw.length >= 12) score += 1;
+    if (/[A-Z]/.test(pw)) score += 1;
+    if (/[0-9]/.test(pw)) score += 1;
+    if (/[^A-Za-z0-9]/.test(pw)) score += 1;
+    return (score / 4) * 100;
+  };
+
+  const changePassword = async (vals: any) => {
+    if (!user?.email) return;
+    if (vals.new !== vals.confirm) {
+      message.error('Passwords do not match');
+      return;
+    }
+    setPwSaving(true);
+    try {
+      const cred = EmailAuthProvider.credential(user.email, vals.current);
+      await reauthenticateWithCredential(auth.currentUser!, cred);
+      await updatePassword(auth.currentUser!, vals.new);
+      message.success('Password updated');
+      pwForm.resetFields();
+      setPwOpen(false);
+    } catch (e: any) {
+      message.error(e.message);
+    } finally {
+      setPwSaving(false);
+    }
+  };
+
+  const downloadData = async () => {
+    if (!uid || !profileRef) return;
+    try {
+      const userSnap = await getDoc(doc(db, 'users', uid));
+      const profileSnap = await getDoc(profileRef);
+      const data = {
+        ...(userSnap.data() || {}),
+        profile: profileSnap.data() || {},
+      };
+      const blob = new Blob([JSON.stringify(data, null, 2)], {
+        type: 'application/json',
+      });
+      saveAs(blob, 'my-data.json');
+    } catch (e: any) {
+      message.error(e.message);
+    }
+  };
+
+  const doDelete = async () => {
+    if (!uid) return;
+    try {
+      const storage = getStorage();
+      try {
+        await deleteObject(storageRef(storage, `avatars/${uid}.png`));
+      } catch {}
+      if (profileRef) {
+        await deleteDoc(profileRef);
+      }
+      await deleteDoc(doc(db, 'users', uid));
+      await deleteUser(auth.currentUser!);
+    } catch (e: any) {
+      message.error(e.message);
+      return;
+    }
+    message.success('Account deleted');
+  };
+
   return (
-    <Card title="Account" className="glass-card" style={{ margin: '2rem', borderRadius: '1.5rem' }}>
+    <Card title="Account Settings" className="glass-card" style={{ margin: '2rem', borderRadius: '1.5rem' }}>
       <Row gutter={[16, 16]}>
         <Col span={24} style={{ textAlign: 'center' }}>
-          <Avatar src={user.photoURL} size={64} />
-          <div style={{ marginTop: 8, fontSize: '1.2rem' }}>{user.displayName}</div>
-          <div>{user.email}</div>
-          {profile.lastSignedInAt &&
-            typeof (profile.lastSignedInAt as Timestamp).toDate === 'function' && (
-              <div style={{ marginTop: 8 }}>
-                Last sign-in:{' '}
-                {(profile.lastSignedInAt as Timestamp).toDate().toLocaleString()}
-              </div>
-            )}
+          <Avatar src={profile.photoURL || user.photoURL || undefined} size={96} />
+          <div style={{ marginTop: 8 }}>
+            <Upload showUploadList={false} beforeUpload={beforeUpload}>
+              <Button icon={<UploadOutlined />}>Change Photo</Button>
+            </Upload>
+          </div>
         </Col>
         <Col span={24}>
-          <Button
-            type="primary"
-            danger
-            onClick={() => signOut(auth)}
-            style={{ marginTop: 16 }}
-          >
-            Sign Out
-          </Button>
+          <Form form={form} layout="vertical" onFinish={saveProfile}>
+            <Form.Item name="displayName" label="Full Name" rules={[{ required: true }]}> <Input /> </Form.Item>
+            <Form.Item name="bio" label="Bio" rules={[{ max: 160 }]}> <Input.TextArea rows={2} /> </Form.Item>
+            <Form.Item name="pronouns" label="Pronouns"> <Input /> </Form.Item>
+            <Form.Item name="username" label="Username" rules={[{ validator: checkUsername }]} validateTrigger="onBlur"> <Input /> </Form.Item>
+            <Form.Item name="email" label="Email" rules={[{ required: true, type: 'email' }]}> <Input /> </Form.Item>
+            <Form.Item>
+              <Button type="primary" htmlType="submit" loading={saving}>Save Changes</Button>
+            </Form.Item>
+          </Form>
+          <Collapse activeKey={pwOpen ? ['pw'] : []} onChange={() => setPwOpen(!pwOpen)}>
+            <Collapse.Panel header="Change Password" key="pw">
+              <Form form={pwForm} layout="vertical" onFinish={changePassword}>
+                <Form.Item name="current" label="Current Password" rules={[{ required: true }]}> <Input.Password /> </Form.Item>
+                <Form.Item name="new" label="New Password" rules={[{ required: true, min: 12, pattern: /[^A-Za-z0-9]/ }]}> <Input.Password /> </Form.Item>
+                <Progress percent={strength(pwForm.getFieldValue('new') || '')} showInfo={false} />
+                <Form.Item name="confirm" label="Confirm Password" dependencies={['new']} rules={[{ required: true }, ({ getFieldValue }) => ({
+                  validator(_, value) {
+                    return !value || getFieldValue('new') === value ? Promise.resolve() : Promise.reject('Passwords do not match');
+                  },
+                })]}>
+                  <Input.Password />
+                </Form.Item>
+                <Form.Item>
+                  <Button type="primary" htmlType="submit" loading={pwSaving}>Update Password</Button>
+                </Form.Item>
+              </Form>
+            </Collapse.Panel>
+          </Collapse>
+          <Card type="inner" title="Danger Zone" style={{ marginTop: 24 }}>
+            <Row gutter={16}>
+              <Col>
+                <Button onClick={downloadData}>Download My Data</Button>
+              </Col>
+              <Col>
+                <Button danger onClick={() => Modal.confirm({ title: 'Delete account?', okText: 'Delete', okButtonProps: { danger: true }, onOk: doDelete })}>Delete Account</Button>
+              </Col>
+            </Row>
+          </Card>
         </Col>
       </Row>
+      <Modal open={photoModal} onOk={uploadPhoto} onCancel={() => setPhotoModal(false)} okText="Save">
+        {photoFile && (
+          <AvatarEditor ref={editorRef} image={photoFile} width={200} height={200} border={50} scale={1} />
+        )}
+      </Modal>
     </Card>
   );
 }

--- a/web/src/react-avatar-editor.d.ts
+++ b/web/src/react-avatar-editor.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-avatar-editor';


### PR DESCRIPTION
## Summary
- add `react-avatar-editor` dependency for image cropping
- implement full account settings UI in `/account`
- wire profile data to Firestore and Firebase Auth
- support profile photo uploads, email updates, username checks, password change
- provide data export and account deletion actions
- fix Firestore document paths in account settings

## Testing
- `pnpm build`
- `pnpm lint` *(fails: 19 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686239c17d748327b6ad249b4e8249dd