### PR TITLE
Fix avatar upload with Firebase storage

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -24,12 +24,29 @@
     "ignore": ["firebase.json","**/.*","**/node_modules/**"],
     "rewrites": [{ "source": "**", "destination": "/index.html" }]
   },
-  "storage": { "rules": "storage.rules" },
+  "storage": {
+    "rules": "storage.rules",
+    "cors": [
+      {
+        "origin": ["http://localhost:5173"],
+        "method": ["GET", "POST", "PUT", "DELETE", "HEAD"],
+        "responseHeader": ["Authorization", "Content-Type"],
+        "maxAgeSeconds": 3600
+      },
+      {
+        "origin": ["https://us-central1-synctimer-dev-464400.cloudfunctions.net"],
+        "method": ["GET", "POST", "PUT", "DELETE", "HEAD"],
+        "responseHeader": ["Authorization", "Content-Type"],
+        "maxAgeSeconds": 3600
+      }
+    ]
+  },
   "emulators": {
     "auth":    { "port": 9099 },
     "functions": { "port": 5001 },
     "firestore": { "port": 8080 },
     "hosting": { "port": 5000 },
+    "storage": { "port": 9199 },
     "ui":      { "enabled": true, "port": 4000 },
     "singleProjectMode": true
   }

--- a/storage.rules
+++ b/storage.rules
@@ -5,6 +5,12 @@ rules_version = '2';
 //    /databases/(default)/documents/users/$(request.auth.uid)).data.isAdmin;
 service firebase.storage {
   match /b/{bucket}/o {
+    // Users may read and write their own avatar
+    match /avatars/{userId}.jpg {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // Deny all other access by default
     match /{allPaths=**} {
       allow read, write: if false;
     }

--- a/web/src/lib/firebase.ts
+++ b/web/src/lib/firebase.ts
@@ -14,6 +14,11 @@ import {
   connectFirestoreEmulator,
   type Firestore,
 } from 'firebase/firestore';
+import {
+  getStorage,
+  connectStorageEmulator,
+  type FirebaseStorage,
+} from 'firebase/storage';
 
 const config = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -37,6 +42,13 @@ export const db: Firestore = getFirestore(app);
 if (import.meta.env.DEV) {
   // point Firestore to emulator on 8080
   connectFirestoreEmulator(db, "127.0.0.1", 8080);
+}
+
+// — Storage setup —
+export const storage: FirebaseStorage = getStorage(app);
+if (import.meta.env.DEV) {
+  // point Storage to emulator on 9199
+  connectStorageEmulator(storage, "127.0.0.1", 9199);
 }
 
 export const googleProvider = new GoogleAuthProvider();


### PR DESCRIPTION
## Summary
- connect Firebase Storage and expose via `storage` export
- revise avatar upload handler to use Storage SDK and maintain state on failure
- allow users to upload their own avatar in `storage.rules`
- enable Storage emulator & CORS configuration

## Testing
- `pnpm lint` in `web`
- `pnpm lint` in `functions`


------
https://chatgpt.com/codex/tasks/task_e_68627627d3d8832787bde0ff59e84520