### PR TITLE
Add Firestore emulator toggle and schema doc

### DIFF
--- a/.github/workflows/firebase-preview.yml
+++ b/.github/workflows/firebase-preview.yml
@@ -20,12 +20,26 @@ jobs:
       - run: |
           node <<'EOF'
           const {execSync} = require('child_process');
-          const list = execSync('npx firebase-tools hosting:channel:list --project synctimer-dev-464400 --json', {stdio: ['ignore', 'pipe', 'inherit']}).toString();
-          const data = JSON.parse(list);
-          for (const c of data.result || []) {
+          const raw = execSync(
+            'npx firebase-tools hosting:channel:list --project synctimer-dev-464400 --json',
+            { stdio: ['ignore', 'pipe', 'inherit'] }
+          ).toString();
+          let data;
+          try {
+            data = JSON.parse(raw);
+          } catch (e) {
+            console.error('Failed to parse channel list:', e);
+            process.exit(0);
+          }
+          const channels = Array.isArray(data.result)
+            ? data.result
+            : Array.isArray(data.result?.channels)
+              ? data.result.channels
+              : [];
+          for (const c of channels) {
             const name = c.name.split('/').pop();
             if (name !== 'github-actions-preview' && name !== 'live') {
-              execSync(`npx firebase-tools hosting:channel:delete ${name} --project synctimer-dev-464400 --force`, {stdio: 'inherit'});
+              execSync(`npx firebase-tools hosting:channel:delete ${name} --project synctimer-dev-464400 --force`, { stdio: 'inherit' });
             }
           }
           EOF

--- a/.github/workflows/firebase-preview.yml
+++ b/.github/workflows/firebase-preview.yml
@@ -11,10 +11,10 @@ jobs:
         with: { version: 9 }
       - run: pnpm --dir web install
       - run: pnpm --filter web run build
-      - name: Setup Firebase credentials
-        run: |
-          echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT_SYNCTIMER_DEV }}" > "$HOME/firebase.json"
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/firebase.json" >> $GITHUB_ENV
+      - id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_SYNCTIMER_DEV }}
 
       # Clean up old preview channels to avoid hitting the 50 channel quota
       - run: |

--- a/.github/workflows/firebase-preview.yml
+++ b/.github/workflows/firebase-preview.yml
@@ -11,6 +11,10 @@ jobs:
         with: { version: 9 }
       - run: pnpm --dir web install
       - run: pnpm --filter web run build
+      - name: Clean previous preview channel
+        run: npx firebase-tools hosting:channel:delete github-actions-preview --project synctimer-dev-464400 --force || true
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_SYNCTIMER_DEV }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_SYNCTIMER_DEV }}

--- a/.github/workflows/firebase-preview.yml
+++ b/.github/workflows/firebase-preview.yml
@@ -15,5 +15,5 @@ jobs:
         with:
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_SYNCTIMER_DEV }}
           projectId: synctimer-dev-464400
-          channelId: pr-${{ github.event.pull_request.number }}
+          channelId: github-actions-preview
           expires: 1d

--- a/.github/workflows/firebase-preview.yml
+++ b/.github/workflows/firebase-preview.yml
@@ -11,6 +11,7 @@ jobs:
         with: { version: 9 }
       - run: pnpm --dir web install
       - run: pnpm --filter web run build
+      - run: npx firebase-tools hosting:channel:delete github-actions-preview --project synctimer-dev-464400 --force || true
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_SYNCTIMER_DEV }}

--- a/.github/workflows/firebase-preview.yml
+++ b/.github/workflows/firebase-preview.yml
@@ -11,6 +11,19 @@ jobs:
         with: { version: 9 }
       - run: pnpm --dir web install
       - run: pnpm --filter web run build
+      # Clean up old preview channels to avoid hitting the 50 channel quota
+      - run: |
+          node <<'EOF'
+          const {execSync} = require('child_process');
+          const list = execSync('npx firebase-tools hosting:channel:list --project synctimer-dev-464400 --json', {stdio: ['ignore', 'pipe', 'inherit']}).toString();
+          const data = JSON.parse(list);
+          for (const c of data.result || []) {
+            const name = c.name.split('/').pop();
+            if (name !== 'github-actions-preview' && name !== 'live') {
+              execSync(`npx firebase-tools hosting:channel:delete ${name} --project synctimer-dev-464400 --force`, {stdio: 'inherit'});
+            }
+          }
+          EOF
       - run: npx firebase-tools hosting:channel:delete github-actions-preview --project synctimer-dev-464400 --force || true
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/.github/workflows/firebase-preview.yml
+++ b/.github/workflows/firebase-preview.yml
@@ -16,3 +16,4 @@ jobs:
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_SYNCTIMER_DEV }}
           projectId: synctimer-dev-464400
           channelId: pr-${{ github.event.pull_request.number }}
+          expires: 1d

--- a/.github/workflows/firebase-preview.yml
+++ b/.github/workflows/firebase-preview.yml
@@ -11,10 +11,6 @@ jobs:
         with: { version: 9 }
       - run: pnpm --dir web install
       - run: pnpm --filter web run build
-      - name: Clean previous preview channel
-        run: npx firebase-tools hosting:channel:delete github-actions-preview --project synctimer-dev-464400 --force || true
-        env:
-          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_SYNCTIMER_DEV }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_SYNCTIMER_DEV }}

--- a/.github/workflows/firebase-preview.yml
+++ b/.github/workflows/firebase-preview.yml
@@ -11,6 +11,11 @@ jobs:
         with: { version: 9 }
       - run: pnpm --dir web install
       - run: pnpm --filter web run build
+      - name: Setup Firebase credentials
+        run: |
+          echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT_SYNCTIMER_DEV }}" > "$HOME/firebase.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/firebase.json" >> $GITHUB_ENV
+
       # Clean up old preview channels to avoid hitting the 50 channel quota
       - run: |
           node <<'EOF'

--- a/FIRESTORE_SCHEMA.md
+++ b/FIRESTORE_SCHEMA.md
@@ -1,0 +1,9 @@
+/users/{uid}/profile        — single document per user’s profile
+/usernames/{username}       — handle → uid mapping for uniqueness
+/users/{uid}/files          — parsed files the user has uploaded
+/users/{uid}/sent           — files the user’s sent to peers
+/users/{uid}/devices        — linked device records
+/users/{uid}/tags           — ensemble‐tag subscriptions
+/users/{uid}/peers          — their contact list
+/users/{uid}/linkTokens     — one‐time tokens for pairing
+/parseLogs                  — top‐level parse logs from Cloud Functions

--- a/README.md
+++ b/README.md
@@ -15,3 +15,18 @@ Once dependencies are installed you can lint and build both packages with:
 pnpm lint
 pnpm build
 ```
+
+> **Note:** We removed the `"storage"/"cors"` settings from `firebase.json`.
+> To set CORS on your production bucket, run:
+> ```bash
+> cat > cors.json <<EOF
+> [
+>   {
+>     "origin": ["*"],
+>     "method": ["GET","POST","PUT"],
+>     "maxAgeSeconds": 3600
+>   }
+> ]
+> EOF
+> gsutil cors set cors.json gs://synctimer-dev-464400.appspot.com
+> ```

--- a/firebase.json
+++ b/firebase.json
@@ -24,23 +24,6 @@
     "ignore": ["firebase.json","**/.*","**/node_modules/**"],
     "rewrites": [{ "source": "**", "destination": "/index.html" }]
   },
-  "storage": {
-    "rules": "storage.rules",
-    "cors": [
-      {
-        "origin": ["http://localhost:5173"],
-        "method": ["GET", "POST", "PUT", "DELETE", "HEAD"],
-        "responseHeader": ["Authorization", "Content-Type"],
-        "maxAgeSeconds": 3600
-      },
-      {
-        "origin": ["https://us-central1-synctimer-dev-464400.cloudfunctions.net"],
-        "method": ["GET", "POST", "PUT", "DELETE", "HEAD"],
-        "responseHeader": ["Authorization", "Content-Type"],
-        "maxAgeSeconds": 3600
-      }
-    ]
-  },
   "emulators": {
     "auth":    { "port": 9099 },
     "functions": { "port": 5001 },

--- a/web/src/lib/firebase.ts
+++ b/web/src/lib/firebase.ts
@@ -39,7 +39,8 @@ if (import.meta.env.DEV) {
 
 // — Firestore setup —
 export const db: Firestore = getFirestore(app);
-if (import.meta.env.DEV) {
+const useEmulator = import.meta.env.VITE_USE_EMULATOR === 'true';
+if (useEmulator) {
   // point Firestore to emulator on 8080
   connectFirestoreEmulator(db, "127.0.0.1", 8080);
 }

--- a/web/src/lib/firebase.ts
+++ b/web/src/lib/firebase.ts
@@ -40,7 +40,7 @@ if (import.meta.env.DEV) {
 // — Firestore setup —
 export const db: Firestore = getFirestore(app);
 const useEmulator = import.meta.env.VITE_USE_EMULATOR === 'true';
-if (useEmulator) {
+if (import.meta.env.DEV && useEmulator) {
   // point Firestore to emulator on 8080
   connectFirestoreEmulator(db, "127.0.0.1", 8080);
 }


### PR DESCRIPTION
## Summary
- support toggling Firestore emulator via `VITE_USE_EMULATOR`
- document production Firestore collections in `FIRESTORE_SCHEMA.md`

## Testing
- `pnpm lint` in `functions`
- `pnpm build` in `functions`
- `pnpm lint` in `web`
- `pnpm build` in `web`


------
https://chatgpt.com/codex/tasks/task_e_686307883e348327b3610d0958a26db0