### PR TITLE
Implement Firestore friend requests

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,12 +11,15 @@ import { AccountLanding } from './pages/AccountLanding';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { useAuthState } from 'react-firebase-hooks/auth';
 import { auth } from './lib/firebase';
-import { Spin, Button } from 'antd';
+import { Spin, Button, Badge } from 'antd';
 import { signOut } from 'firebase/auth';
+import { BellOutlined } from '@ant-design/icons';
+import { useIncomingCount } from './hooks/useFriends';
 
 
 export function App() {
   const [user, loading] = useAuthState(auth);
+  const incoming = useIncomingCount();
   if (loading) return <Spin />;
 
   return (
@@ -28,6 +31,9 @@ export function App() {
           <Link to="/files">Files</Link>
           <Link to="/groups">Groups</Link>
           <Link to="/contacts">Contacts</Link>
+          <Badge count={incoming} offset={[0,0]}>
+            <BellOutlined style={{ fontSize: 18, marginLeft: 8 }} />
+          </Badge>
           <Link to="/devices">Link Phone</Link>
           <Button type="link" onClick={() => signOut(auth)}>
             Sign Out

--- a/web/src/components/ContactsOld.tsx
+++ b/web/src/components/ContactsOld.tsx
@@ -1,0 +1,140 @@
+import { useState } from 'react';
+import {
+  Card,
+  Button,
+  Modal,
+  Input,
+  message,
+  Spin,
+  Alert,
+  Row,
+  Col,
+  Avatar,
+  Tag,
+} from 'antd';
+import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
+import { usePeers } from '../hooks/usePeers';
+import type { Peer } from '../hooks/usePeers';
+import { sendPeerRequest, removePeer } from '../lib/api';
+import { auth } from '../lib/firebase';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
+
+export function Contacts() {
+  const { peers, loading, error } = usePeers();
+  const uid = auth.currentUser?.uid;
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [email, setEmail] = useState('');
+  const [sending, setSending] = useState(false);
+
+  const sendRequest = async () => {
+    if (!uid || !email) return;
+    setSending(true);
+    try {
+      await sendPeerRequest(email, uid);
+      message.success('Request sent');
+      setModalOpen(false);
+      setEmail('');
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      message.error(msg);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const confirmRemove = (peer: Peer) => {
+    Modal.confirm({
+      title: 'Remove peer?',
+      content: `Are you sure you want to remove ${peer.displayName || peer.email}?`,
+      okText: 'Remove',
+      okButtonProps: { danger: true },
+      onOk: () => doRemove(peer.id),
+    });
+  };
+
+  const doRemove = async (peerUid: string) => {
+    if (!uid) return;
+    try {
+      await removePeer(peerUid, uid);
+      message.success('Peer removed');
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      message.error(msg);
+    }
+  };
+
+  const glassStyle = {
+    borderRadius: '1.5rem',
+  } as const;
+
+  return (
+    <Card
+      title="Peers"
+      className="glass-card"
+      style={{ ...glassStyle, margin: '2rem' }}
+      extra={
+        <Button type="primary" icon={<PlusOutlined />} onClick={() => setModalOpen(true)}>
+          Add Peer
+        </Button>
+      }
+    >
+        {loading ? (
+          <Spin />
+      ) : error ? (
+        <Alert type="error" message={error.message} />
+      ) : peers.length === 0 ? (
+        <div>No peers yet.</div>
+      ) : (
+        <Row gutter={[16, 16]}>
+          <TransitionGroup component={null}>
+            {peers.map((p) => (
+              <CSSTransition key={p.id} timeout={250} classNames="fade">
+                <Col xs={24} sm={12} md={8} lg={6}>
+                  <Card
+                    className="glass-card"
+                    style={glassStyle}
+                    actions={[<DeleteOutlined key="del" onClick={() => confirmRemove(p)} />]}
+                  >
+                    <Card.Meta
+                      avatar={<Avatar src={p.photoURL} />}
+                      title={p.displayName || p.email}
+                      description={
+                        <>
+                          <div>{p.email}</div>
+                          <div>{p.linkedAt?.toDate().toLocaleDateString()}</div>
+                        </>
+                      }
+                    />
+                    <div style={{ marginTop: 8 }}>
+                      {p.tags?.map((t) => (
+                        <Tag key={t}>{t}</Tag>
+                      ))}
+                    </div>
+                  </Card>
+                </Col>
+              </CSSTransition>
+            ))}
+          </TransitionGroup>
+        </Row>
+      )}
+
+      <Modal
+        title="Add Peer"
+        open={modalOpen}
+        onOk={sendRequest}
+        okText="Send Request"
+        confirmLoading={sending}
+        onCancel={() => setModalOpen(false)}
+      >
+        <Input
+          placeholder="Peer email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          onPressEnter={sendRequest}
+          autoFocus
+        />
+      </Modal>
+    </Card>
+  );
+}

--- a/web/src/hooks/useFriends.ts
+++ b/web/src/hooks/useFriends.ts
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react';
+import { useAuthState } from 'react-firebase-hooks/auth';
+import {
+  collection,
+  doc,
+  onSnapshot,
+  getDoc,
+  type DocumentData,
+} from 'firebase/firestore';
+import { auth, db } from '../lib/firebase';
+
+export interface UserInfo {
+  id: string;
+  displayName?: string;
+  handle?: string;
+  photoURL?: string;
+  email?: string;
+}
+
+export interface FriendsState {
+  contacts: UserInfo[];
+  incoming: UserInfo[];
+  outgoing: UserInfo[];
+  loading: boolean;
+}
+
+export function useFriends(): FriendsState {
+  const [user] = useAuthState(auth);
+  const uid = user?.uid;
+
+  const [contacts, setContacts] = useState<UserInfo[]>([]);
+  const [incoming, setIncoming] = useState<UserInfo[]>([]);
+  const [outgoing, setOutgoing] = useState<UserInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!uid) return;
+    setLoading(true);
+    const unsubContacts = onSnapshot(
+      collection(db, 'users', uid, 'contacts'),
+      async snap => {
+        const arr: UserInfo[] = [];
+        for (const d of snap.docs) {
+          const u = await getDoc(doc(db, 'users', d.id));
+          if (u.exists()) {
+            const data = u.data() as DocumentData;
+            arr.push({ id: d.id, ...data } as UserInfo);
+          }
+        }
+        setContacts(arr);
+        setLoading(false);
+      },
+    );
+    const unsubIncoming = onSnapshot(
+      collection(db, 'users', uid, 'incomingRequests'),
+      async snap => {
+        const arr: UserInfo[] = [];
+        for (const d of snap.docs) {
+          const u = await getDoc(doc(db, 'users', d.id));
+          if (u.exists()) arr.push({ id: d.id, ...(u.data() as DocumentData) });
+        }
+        setIncoming(arr);
+      },
+    );
+    const unsubOutgoing = onSnapshot(
+      collection(db, 'users', uid, 'outgoingRequests'),
+      async snap => {
+        const arr: UserInfo[] = [];
+        for (const d of snap.docs) {
+          const u = await getDoc(doc(db, 'users', d.id));
+          if (u.exists()) arr.push({ id: d.id, ...(u.data() as DocumentData) });
+        }
+        setOutgoing(arr);
+      },
+    );
+    return () => {
+      unsubContacts();
+      unsubIncoming();
+      unsubOutgoing();
+    };
+  }, [uid]);
+
+  return { contacts, incoming, outgoing, loading };
+}
+
+export function useIncomingCount(): number {
+  const [user] = useAuthState(auth);
+  const uid = user?.uid;
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!uid) return;
+    const unsub = onSnapshot(collection(db, 'users', uid, 'incomingRequests'), snap => {
+      setCount(snap.size);
+    });
+    return unsub;
+  }, [uid]);
+  return count;
+}

--- a/web/src/hooks/useUserSearch.ts
+++ b/web/src/hooks/useUserSearch.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import {
+  collection,
+  getDocs,
+  query,
+  limit,
+  orderBy,
+  startAt,
+  endAt,
+  type DocumentData,
+} from 'firebase/firestore';
+import { db } from '../lib/firebase';
+
+import type { UserInfo } from './useFriends';
+
+export function useUserSearch(term: string): UserInfo[] {
+  const [results, setResults] = useState<UserInfo[]>([]);
+
+  useEffect(() => {
+    if (!term) {
+      setResults([]);
+      return;
+    }
+    const t = term.toLowerCase();
+    (async () => {
+      const arr: UserInfo[] = [];
+      const byHandle = query(
+        collection(db, 'users'),
+        orderBy('handle'),
+        startAt(t),
+        endAt(t + '\uf8ff'),
+        limit(5),
+      );
+      const handleSnap = await getDocs(byHandle);
+      handleSnap.forEach(d => arr.push({ id: d.id, ...(d.data() as DocumentData) }));
+
+      if (term.includes('@')) {
+        const byEmail = query(
+          collection(db, 'users'),
+          orderBy('email'),
+          startAt(t),
+          endAt(t + '\uf8ff'),
+          limit(5),
+        );
+        const emailSnap = await getDocs(byEmail);
+        emailSnap.forEach(d => {
+          if (!arr.some(u => u.id === d.id))
+            arr.push({ id: d.id, ...(d.data() as DocumentData) });
+        });
+      }
+      setResults(arr);
+    })();
+  }, [term]);
+
+  return results;
+}


### PR DESCRIPTION
## Summary
- build a new real‑time contact system
- show notifications in the nav bar
- add hooks for friend data and search
- update Contacts page with tabs for friends and requests

## Testing
- `pnpm lint`
- `pnpm build`
- `cd functions && pnpm lint`
- `cd functions && pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68634c1e46c88327820a594cc66f25d0