### PR TITLE
Fix contact removal and enforce unique user fields

### DIFF
--- a/web/src/components/Account.tsx
+++ b/web/src/components/Account.tsx
@@ -22,6 +22,7 @@ import {
   updateProfile,
   updateEmail,
   updatePassword,
+  fetchSignInMethodsForEmail,
   EmailAuthProvider,
   reauthenticateWithCredential,
   deleteUser,
@@ -369,20 +370,9 @@ export function Account() {
         return '3-32 letters, numbers or _';
 
       const lower = value.toLowerCase();
-      const userCol = collection(db, 'users');
-
-      // potential fields where username might live
-      const checks = [
-        query(userCol, where('usernameLower', '==', lower)),
-        query(userCol, where('profile.usernameLower', '==', lower)),
-        query(userCol, where('username', '==', value)),
-        query(userCol, where('profile.username', '==', value)),
-      ];
-
-      for (const q of checks) {
-        const snap = await getDocs(q);
-        const taken = snap.docs.find((d) => d.id !== uid);
-        if (taken) return 'This username is already taken.';
+      const snap = await getDoc(doc(db, 'usernames', lower));
+      if (snap.exists() && snap.data()?.uid !== uid) {
+        return 'This username is already taken.';
       }
 
     } else if (field === 'email') {
@@ -409,12 +399,43 @@ export function Account() {
     if (err || value === original[field]) return;
     setSavingField(field);
     try {
-      const data: Record<string, unknown> = { [field]: value };
-      if (field === 'username') data.usernameLower = value.toLowerCase();
-      await updateDoc(profileRef, data as DocumentData);
-      if (field === 'displayName')
-        await updateProfile(auth.currentUser!, { displayName: value });
-      if (field === 'email') await updateEmail(auth.currentUser!, value);
+      if (field === 'username') {
+        const lower = value.toLowerCase();
+        const ref = doc(db, 'usernames', lower);
+        const snap = await getDoc(ref);
+        if (snap.exists() && snap.data()?.uid !== uid) {
+          message.error('Username already taken');
+          animate('username', 'error');
+          setValues((v) => ({ ...v, username: original.username }));
+          setUsername(original.username);
+          return;
+        }
+        const batchData: Record<string, unknown> = {
+          username: value,
+          usernameLower: lower,
+        };
+        await updateDoc(profileRef, batchData as DocumentData);
+        await setDoc(ref, { uid });
+        const oldLower = original.username.toLowerCase();
+        if (oldLower && oldLower !== lower) {
+          await deleteDoc(doc(db, 'usernames', oldLower));
+        }
+      } else if (field === 'email') {
+        const methods = await fetchSignInMethodsForEmail(auth, value);
+        if (methods.length > 0 && value !== auth.currentUser?.email) {
+          message.error('Email already in use');
+          animate('email', 'error');
+          setValues((v) => ({ ...v, email: original.email }));
+          return;
+        }
+        await updateEmail(auth.currentUser!, value);
+        await updateDoc(profileRef, { email: value } as DocumentData);
+      } else {
+        const data: Record<string, unknown> = { [field]: value };
+        await updateDoc(profileRef, data as DocumentData);
+        if (field === 'displayName')
+          await updateProfile(auth.currentUser!, { displayName: value });
+      }
       message.success(`${field} updated`);
       animate(field, 'success');
       setOriginal((o) => ({ ...o, [field]: value }));
@@ -718,9 +739,20 @@ export function Account() {
                     setUsername(e.target.value);
                     setValues({ ...values, username: e.target.value });
                   }}
+                  disabled={savingField === 'username'}
                   onBlur={() => saveField('username')}
                 />
-                <Button size="small" type="primary" onClick={() => saveField('username')} disabled={values.username === original.username || !!errors.username} loading={savingField === 'username'}>
+                <Button
+                  size="small"
+                  type="primary"
+                  onClick={() => saveField('username')}
+                  disabled={
+                    savingField === 'username' ||
+                    values.username === original.username ||
+                    !!errors.username
+                  }
+                  loading={savingField === 'username'}
+                >
                   Save
                 </Button>
               </div>
@@ -734,9 +766,20 @@ export function Account() {
                   style={{ flex: 1 }}
                   value={values.email}
                   onChange={(e) => setValues({ ...values, email: e.target.value })}
+                  disabled={savingField === 'email'}
                   onBlur={() => saveField('email')}
                 />
-                <Button size="small" type="primary" onClick={() => saveField('email')} disabled={values.email === original.email || !!errors.email} loading={savingField === 'email'}>
+                <Button
+                  size="small"
+                  type="primary"
+                  onClick={() => saveField('email')}
+                  disabled={
+                    savingField === 'email' ||
+                    values.email === original.email ||
+                    !!errors.email
+                  }
+                  loading={savingField === 'email'}
+                >
                   Save
                 </Button>
               </div>

--- a/web/src/components/Contacts.tsx
+++ b/web/src/components/Contacts.tsx
@@ -19,6 +19,7 @@ import {
   deleteDoc,
 } from 'firebase/firestore';
 import { auth, db } from '../lib/firebase';
+import { removeFriend } from '../lib/friends';
 import { useFriends } from '../hooks/useFriends';
 import { useUserSearch } from '../hooks/useUserSearch';
 import type { UserInfo } from '../hooks/useFriends';
@@ -26,12 +27,13 @@ import type { UserInfo } from '../hooks/useFriends';
 export function Contacts() {
   const uid = auth.currentUser?.uid;
   const reduce = useReducedMotion() ?? false;
-  const { contacts, incoming, outgoing, loading } = useFriends();
+  const { contacts, incoming, outgoing, loading, refetch } = useFriends();
 
   const [search, setSearch] = useState('');
   const results = useUserSearch(search);
   const [selected, setSelected] = useState<UserInfo | null>(null);
   const [adding, setAdding] = useState(false);
+  const [removing, setRemoving] = useState<string | null>(null);
 
   const sendRequest = async () => {
     if (!uid || !selected) return;
@@ -96,14 +98,14 @@ export function Contacts() {
     if (!uid) return;
     Modal.confirm({
       title: 'Remove contact?',
-      okButtonProps: { danger: true },
+      okButtonProps: { danger: true, loading: removing === other.id },
       onOk: async () => {
+        setRemoving(other.id);
         try {
-          await deleteDoc(doc(db, 'users', uid, 'contacts', other.id));
-          await deleteDoc(doc(db, 'users', other.id, 'contacts', uid));
-          message.success('Removed');
-        } catch (e: unknown) {
-          message.error((e as Error).message || String(e));
+          await removeFriend(other.id);
+          await refetch();
+        } finally {
+          setRemoving(null);
         }
       },
     });
@@ -133,6 +135,7 @@ export function Contacts() {
                         key="del"
                         danger
                         icon={<DeleteOutlined />}
+                        disabled={removing === c.id}
                         onClick={() => remove(c)}
                       >
                         Remove

--- a/web/src/lib/friends.ts
+++ b/web/src/lib/friends.ts
@@ -1,0 +1,23 @@
+import { doc, deleteDoc } from 'firebase/firestore';
+import { auth, db } from './firebase';
+import { message } from 'antd';
+
+/**
+ * Remove a friend connection for both users.
+ * Deletes the docs in each user's contacts subcollection.
+ */
+export async function removeFriend(friendUid: string): Promise<void> {
+  const currentUid = auth.currentUser?.uid;
+  if (!currentUid) throw new Error('Not authenticated');
+  try {
+    await Promise.all([
+      deleteDoc(doc(db, 'users', currentUid, 'contacts', friendUid)),
+      deleteDoc(doc(db, 'users', friendUid, 'contacts', currentUid)),
+    ]);
+    message.success('Friend removed');
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    message.error(msg);
+    throw e;
+  }
+}


### PR DESCRIPTION
## Summary
- add stateful `refetch` capability to `useFriends`
- update `removeFriend` to derive current UID and update UI after deletion
- wire Contacts page to refresh after removing a friend
- enforce global username/email uniqueness when saving account info

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6863521557708327a3efaf2681e0c056