### PR TITLE
Add responsive sidebar layout with animations

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,7 +3,6 @@ import {
   BrowserRouter,
   Routes,
   Route,
-  NavLink,
   Navigate,
 } from 'react-router-dom';
 import { UploadValidate } from './components/UploadValidate';
@@ -17,66 +16,25 @@ import { AccountLanding } from './pages/AccountLanding';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { useAuthState } from 'react-firebase-hooks/auth';
 import { auth } from './lib/firebase';
-import { Spin, Button, Badge } from 'antd';
-import { signOut } from 'firebase/auth';
-import { BellOutlined } from '@ant-design/icons';
-import { useIncomingCount } from './hooks/useFriends';
-import { motion } from 'framer-motion';
+import { Spin } from 'antd';
 import { PageAnimator } from './components/PageAnimator';
+import { Sidebar } from './components/Sidebar';
 
 
 export function App() {
-  const [user, loading] = useAuthState(auth);
-  const incoming = useIncomingCount();
+  const [, loading] = useAuthState(auth);
   if (loading) return <Spin />;
 
   return (
     <BrowserRouter>
-      {user && (
-        <nav className="glass-nav">
-          {[
-            ['/account', 'Account'],
-            ['/parse', 'Validate XML'],
-            ['/files', 'Files'],
-            ['/groups', 'Groups'],
-            ['/contacts', 'Contacts'],
-          ].map(([to, label]) => (
-            <NavLink key={to} to={to} className="nav-link">
-              {({ isActive }) => (
-                <span className="relative">
-                  {label}
-                  {isActive && (
-                    <motion.div layoutId="nav-highlight" className="nav-highlight" />
-                  )}
-                </span>
-              )}
-            </NavLink>
-          ))}
-          <Badge count={incoming} offset={[0, 0]}>
-            <BellOutlined style={{ fontSize: 18, marginLeft: 8 }} />
-          </Badge>
-          <NavLink to="/devices" className="nav-link">
-            {({ isActive }) => (
-              <span className="relative">
-                Link Phone
-                {isActive && (
-                  <motion.div layoutId="nav-highlight" className="nav-highlight" />
-                )}
-              </span>
-            )}
-          </NavLink>
-          <Button type="link" onClick={() => signOut(auth)}>
-            Sign Out
-          </Button>
-        </nav>
-      )}
-      <PageAnimator>
-        <Routes>
-          <Route path="/" element={<AccountLanding />} />
-          <Route
-            path="/account"
-            element={auth.currentUser ? <AccountProfile /> : <AccountLanding />}
-          />
+      <Sidebar>
+        <PageAnimator>
+          <Routes>
+            <Route path="/" element={<AccountLanding />} />
+            <Route
+              path="/account"
+              element={auth.currentUser ? <AccountProfile /> : <AccountLanding />}
+            />
           <Route
             path="/parse"
             element={
@@ -126,7 +84,8 @@ export function App() {
             }
           />
         </Routes>
-      </PageAnimator>
+        </PageAnimator>
+      </Sidebar>
     </BrowserRouter>
   );
 }

--- a/web/src/components/PageAnimator.tsx
+++ b/web/src/components/PageAnimator.tsx
@@ -10,7 +10,7 @@ export function PageAnimator({ children }: { children: ReactNode }) {
   const variants = pageVariants(reduce);
 
   return (
-    <AnimatePresence initial={false} mode="sync">
+    <AnimatePresence initial={false} mode="wait">
       <motion.div
         key={location.pathname}
         variants={variants}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,0 +1,113 @@
+import { NavLink } from 'react-router-dom';
+import {
+  UserOutlined,
+  FileSearchOutlined,
+  FileOutlined,
+  TeamOutlined,
+  ContactsOutlined,
+  MobileOutlined,
+  MenuOutlined,
+  LogoutOutlined,
+  BellOutlined,
+} from '@ant-design/icons';
+import { Drawer, Button } from 'antd';
+import { useState, type ReactNode } from 'react';
+import { signOut } from 'firebase/auth';
+import { auth } from '../lib/firebase';
+import { useIncomingCount } from '../hooks/useFriends';
+import { Badge } from 'antd';
+import { useMediaQuery } from '../hooks/useMediaQuery';
+
+interface SidebarProps {
+  children: ReactNode;
+}
+
+export function Sidebar({ children }: SidebarProps) {
+  const isMobile = useMediaQuery('(max-width: 768px)');
+  const [open, setOpen] = useState(false);
+  const [collapsed, setCollapsed] = useState(
+    () => localStorage.getItem('sidebarCollapsed') === '1',
+  );
+  const incoming = useIncomingCount();
+
+  const toggleCollapse = () => {
+    const next = !collapsed;
+    setCollapsed(next);
+    localStorage.setItem('sidebarCollapsed', next ? '1' : '0');
+  };
+
+  const links = [
+    ['/account', 'Account', <UserOutlined />],
+    ['/parse', 'Validate XML', <FileSearchOutlined />],
+    ['/files', 'Files', <FileOutlined />],
+    ['/groups', 'Groups', <TeamOutlined />],
+    ['/contacts', 'Contacts', <ContactsOutlined />],
+    ['/devices', 'Devices', <MobileOutlined />],
+  ] as const;
+
+  const nav = (
+    <div className="sidebar-content">
+      <nav>
+        {links.map(([to, label, icon]) => (
+          <NavLink key={to} to={to} className="sidebar-link">
+            {({ isActive }) => (
+              <span className="link-inner">
+                {icon}
+                {!collapsed && (
+                  <span className={isActive ? 'active' : undefined}>{label}</span>
+                )}
+              </span>
+            )}
+          </NavLink>
+        ))}
+        <div className="incoming">
+          <Badge count={incoming} offset={[0, 0]}>
+            <BellOutlined />
+          </Badge>
+        </div>
+      </nav>
+      <div className="sidebar-footer">
+        <Button type="text" onClick={toggleCollapse} icon={<MenuOutlined />} />
+        {!collapsed && auth.currentUser && (
+          <Button
+            type="text"
+            onClick={() => signOut(auth)}
+            icon={<LogoutOutlined />}
+          />
+        )}
+      </div>
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <div className="layout mobile">
+        <div className="topbar">
+          <Button
+            type="text"
+            icon={<MenuOutlined />}
+            onClick={() => setOpen(true)}
+          />
+        </div>
+        <Drawer
+          placement="left"
+          closable={false}
+          onClose={() => setOpen(false)}
+          open={open}
+          width={256}
+          bodyStyle={{ padding: 0 }}
+        >
+          {nav}
+        </Drawer>
+        <main className="content">{children}</main>
+      </div>
+    );
+  }
+
+  return (
+    <div className="layout">
+      <aside className={collapsed ? 'sidebar collapsed' : 'sidebar'}>{nav}</aside>
+      <main className="content">{children}</main>
+    </div>
+  );
+}

--- a/web/src/hooks/useMediaQuery.ts
+++ b/web/src/hooks/useMediaQuery.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() =>
+    typeof window !== 'undefined' ? window.matchMedia(query).matches : false,
+  );
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    const listener = () => setMatches(media.matches);
+    media.addEventListener('change', listener);
+    setMatches(media.matches);
+    return () => media.removeEventListener('change', listener);
+  }, [query]);
+
+  return matches;
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -216,3 +216,106 @@ button:focus-visible {
 .animate-error {
   animation: error-shake 300ms ease-in-out;
 }
+
+/* Sidebar Layout */
+.layout {
+  display: flex;
+  min-height: 100vh;
+}
+
+.layout.mobile {
+  flex-direction: column;
+}
+
+.sidebar {
+  position: fixed;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 16rem;
+  color: #fff;
+  background: linear-gradient(#70c73c, #4a8a2e);
+  z-index: 100;
+}
+
+.sidebar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(45deg, rgba(255, 255, 255, 0.05) 0, rgba(255, 255, 255, 0.05) 2px, transparent 2px, transparent 4px);
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.sidebar::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(128, 128, 128, 0.3);
+  mix-blend-mode: multiply;
+  pointer-events: none;
+}
+
+.sidebar.collapsed {
+  width: 4rem;
+}
+
+.sidebar-content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.sidebar-link {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.5rem 1rem;
+  color: #fff;
+  text-decoration: none;
+}
+
+.sidebar-link .active {
+  font-weight: bold;
+  color: #fff;
+}
+
+.sidebar-footer {
+  margin-top: auto;
+  padding: 1rem;
+  display: flex;
+  justify-content: space-between;
+}
+
+.incoming {
+  padding: 1.5rem 1rem;
+}
+
+.content {
+  flex: 1;
+  margin-left: 16rem;
+  padding: 1rem;
+  transition: margin-left 250ms var(--ease);
+}
+
+.sidebar.collapsed + .content {
+  margin-left: 4rem;
+}
+
+.layout.mobile .content {
+  margin-left: 0;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  height: 4rem;
+  padding: 0 1rem;
+  background: linear-gradient(#70c73c, #4a8a2e);
+  color: #fff;
+}
+
+.topbar button {
+  color: #fff;
+}

--- a/web/src/theme/motion.ts
+++ b/web/src/theme/motion.ts
@@ -1,7 +1,7 @@
 export const motion = {
   easing: [0.4, 0, 0.2, 1] as [number, number, number, number],
   durations: {
-    pageEnter: 0.3,
+    pageEnter: 0.25,
     pageExit: 0.25,
     card: 0.3,
     stagger: 0.05,
@@ -11,20 +11,23 @@ export const motion = {
 export const pageVariants = (reduce: boolean) => ({
   initial: {
     opacity: 0,
-    ...(reduce ? {} : { filter: 'blur(8px)', scale: 0.98 }),
+    x: 32,
+    ...(reduce ? {} : { filter: 'blur(8px)', scale: 0.95 }),
   },
   animate: {
     opacity: 1,
+    x: 0,
     ...(reduce ? {} : { filter: 'blur(0px)', scale: 1 }),
     transition: {
       duration: motion.durations.pageEnter,
       ease: motion.easing,
-      delay: 0.05,
+      delay: motion.durations.pageExit,
     },
   },
   exit: {
     opacity: 0,
-    ...(reduce ? {} : { filter: 'blur(8px)', scale: 0.98 }),
+    x: -32,
+    ...(reduce ? {} : { filter: 'blur(8px)', scale: 0.95 }),
     transition: { duration: motion.durations.pageExit, ease: motion.easing },
   },
 });


### PR DESCRIPTION
## Summary
- implement Sidebar with collapse, drawer and navigation icons
- shift routing to new Sidebar layout
- add slide/blur page transitions
- update global styles for sidebar gradient and mobile topbar
- utility hook `useMediaQuery`

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68638004b6c48327af1f224c05525222