### PR TITLE
Use Monaco editor for parse page

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -295,3 +295,28 @@ button:focus-visible {
 
 }
 
+/* Modern drop zone for UploadValidate */
+.drop-zone {
+  border: 2px dashed rgba(0, 0, 0, 0.3);
+  border-radius: 1rem;
+  padding: 2rem;
+  text-align: center;
+  transition: background-color 0.2s var(--ease), border-color 0.2s var(--ease);
+  cursor: pointer;
+}
+
+.drop-zone:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.drop-zone.active {
+  border-color: var(--accent);
+  background: rgba(112, 199, 60, 0.15);
+}
+
+.drop-zone-icon {
+  font-size: 3rem;
+  color: var(--accent);
+  margin-bottom: 0.5rem;
+}
+


### PR DESCRIPTION
## Summary
- switch XML textarea to Monaco and lazy-load editor
- add syntax validation and Ctrl/Cmd+Enter shortcut
- modernize drag & drop zone
- keep YAML preview card with glass style

## Testing
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686390f9e5d48327836291e5ae54cf8f