### PR TITLE
Add global Link Device modal

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,7 +8,7 @@ import {
 import { UploadValidate } from './components/UploadValidate';
 import { Files } from './components/Files';
 import { Contacts } from './components/Contacts';
-import { Devices } from './components/Devices';
+import { LinkDeviceModal } from './components/LinkDeviceModal';
 import { Groups } from './components/Groups';
 
 import { Account as AccountProfile } from './components/Account';
@@ -70,14 +70,6 @@ export function App() {
             }
           />
           <Route
-            path="/devices"
-            element={
-              <ProtectedRoute>
-                <Devices />
-              </ProtectedRoute>
-            }
-          />
-          <Route
             path="*"
             element={
               <ProtectedRoute>
@@ -88,6 +80,7 @@ export function App() {
         </Routes>
         </PageAnimator>
       </MainContent>
+      <LinkDeviceModal />
     </BrowserRouter>
   );
 }

--- a/web/src/components/LinkDeviceModal.tsx
+++ b/web/src/components/LinkDeviceModal.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import { Button, Modal, Tooltip, message, Alert } from 'antd';
+import { MobileOutlined, CloseOutlined } from '@ant-design/icons';
+import { auth } from '../lib/firebase';
+import { getLinkToken } from '../lib/api';
+import Devices from './Devices';
+import { useLocation } from 'react-router-dom';
+
+export function LinkDeviceModal() {
+  const [open, setOpen] = useState(false);
+  const [token, setToken] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const location = useLocation();
+
+  useEffect(() => {
+    setOpen(false);
+  }, [location.pathname]);
+
+  const fetchToken = async () => {
+    const uid = auth.currentUser?.uid;
+    if (!uid) return;
+    try {
+      const t = await getLinkToken(uid);
+      setToken(t);
+      setError(null);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(msg);
+      message.error(msg);
+    }
+  };
+
+  useEffect(() => {
+    if (open && !token) {
+      fetchToken();
+    }
+  }, [open, token]);
+
+  if (!auth.currentUser) return null;
+
+  return (
+    <>
+      <Tooltip title="Link Device">
+        <Button
+          type="primary"
+          shape="circle"
+          icon={<MobileOutlined />}
+          onClick={() => setOpen(true)}
+          style={{ position: 'fixed', bottom: '2rem', right: '2rem', zIndex: 1000 }}
+        />
+      </Tooltip>
+      <Modal
+        className="glass-modal"
+        open={open}
+        onCancel={() => setOpen(false)}
+        footer={null}
+        destroyOnClose={false}
+        maskStyle={{ backdropFilter: 'blur(8px)', backgroundColor: 'rgba(255,255,255,0.125)' }}
+        bodyStyle={{ padding: 0 }}
+        closeIcon={<CloseOutlined />}
+        aria-labelledby="link-device-title"
+        aria-describedby="link-device-desc"
+        transitionName="fade-scale"
+        maskTransitionName="fade"
+      >
+        {error && (
+          <Alert
+            type="error"
+            message={error}
+            action={<Button size="small" onClick={fetchToken}>Retry</Button>}
+            style={{ marginBottom: 8 }}
+          />
+        )}
+        <div id="link-device-desc">
+          <Devices linkToken={token ?? undefined} />
+        </div>
+      </Modal>
+    </>
+  );
+}
+

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -10,7 +10,6 @@ import {
   FolderOpenOutlined,
   TeamOutlined,
   ContactsOutlined,
-  MobileOutlined,
 } from '@ant-design/icons';
 
 export function Sidebar() {
@@ -37,7 +36,6 @@ export function Sidebar() {
     ['/files', 'Files', <FolderOpenOutlined />],
     ['/groups', 'Groups', <TeamOutlined />],
     ['/contacts', 'Contacts', <ContactsOutlined />],
-    ['/devices', 'Devices', <MobileOutlined />],
   ] as const;
 
   const content = (

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -295,3 +295,32 @@ button:focus-visible {
 
 }
 
+/* transition for link device modal */
+.fade-scale-enter,
+.fade-scale-appear {
+  opacity: 0;
+  transform: scale(0.95);
+}
+.fade-scale-enter-active,
+.fade-scale-appear-active {
+  opacity: 1;
+  transform: scale(1);
+  transition: opacity 250ms var(--ease), transform 250ms var(--ease);
+}
+.fade-scale-leave {
+  opacity: 1;
+  transform: scale(1);
+}
+.fade-scale-leave-active {
+  opacity: 0;
+  transform: scale(0.95);
+  transition: opacity 250ms var(--ease), transform 250ms var(--ease);
+}
+
+.glass-modal .ant-modal-content {
+  background: rgba(255, 255, 255, 0.4);
+  backdrop-filter: blur(12px);
+  border-radius: 1.5rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+


### PR DESCRIPTION
## Summary
- implement persistent LinkDeviceModal available on every page
- remove standalone devices route and sidebar link
- update `Devices` to accept link token
- style modal with glassmorphic theme and fade-scale animation

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686397cf8f008327b1de2ffa3fa20245