### PR TITLE
Introduce Explore page and clean up tag management

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,8 @@ import { Files } from './components/Files';
 import { Contacts } from './components/Contacts';
 import { LinkDeviceModal } from './components/LinkDeviceModal';
 import { Groups } from './components/Groups';
+import { Explore } from './components/Explore';
+import { TagDetail } from './components/TagDetail';
 
 import { Account as AccountProfile } from './components/Account';
 import { AccountLanding } from './pages/AccountLanding';
@@ -58,6 +60,22 @@ export function App() {
             element={
               <ProtectedRoute>
                 <Groups />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/explore"
+            element={
+              <ProtectedRoute>
+                <Explore />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/explore/:tagId"
+            element={
+              <ProtectedRoute>
+                <TagDetail />
               </ProtectedRoute>
             }
           />

--- a/web/src/components/Explore.tsx
+++ b/web/src/components/Explore.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Card, Input, List, Button, Tag as AntTag, Spin } from 'antd';
+import { useAuthState } from 'react-firebase-hooks/auth';
+import { collection, getDocs, query, orderBy, limit, startAfter, where, doc, getDoc, setDoc, deleteDoc, type DocumentData, QueryDocumentSnapshot } from 'firebase/firestore';
+import { useNavigate } from 'react-router-dom';
+import { auth, db } from '../lib/firebase';
+import { motion, useReducedMotion } from 'framer-motion';
+import { cardVariants, motion as m } from '../theme/motion';
+
+interface TagInfo {
+  id: string;
+  name: string;
+  type?: string;
+  memberCount?: number;
+}
+
+function useDebounce<T>(value: T, delay: number): T {
+  const [val, setVal] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setVal(value), delay);
+    return () => clearTimeout(t);
+  }, [value, delay]);
+  return val;
+}
+
+export function Explore() {
+  const [user] = useAuthState(auth);
+  const uid = user?.uid;
+  const navigate = useNavigate();
+  const reduce = useReducedMotion() ?? false;
+
+  const [search, setSearch] = useState('');
+  const debounced = useDebounce(search, 400);
+  const [searchResults, setSearchResults] = useState<TagInfo[]>([]);
+
+  const [yourTags, setYourTags] = useState<TagInfo[]>([]);
+  const [trending, setTrending] = useState<TagInfo[]>([]);
+  const [featured, setFeatured] = useState<TagInfo[]>([]);
+
+  const [trendCursor, setTrendCursor] = useState<QueryDocumentSnapshot<DocumentData> | null>(null);
+  const [featCursor, setFeatCursor] = useState<QueryDocumentSnapshot<DocumentData> | null>(null);
+  const [trendMore, setTrendMore] = useState(true);
+  const [featMore, setFeatMore] = useState(true);
+  const [loadingTrend, setLoadingTrend] = useState(false);
+  const [loadingFeat, setLoadingFeat] = useState(false);
+
+  const joinTag = useCallback(async (id: string) => {
+    if (!uid) return;
+    const lower = id.toLowerCase();
+    await setDoc(doc(db, 'tags', lower), { name: lower }, { merge: true });
+    await setDoc(doc(db, 'tags', lower, 'members', uid), {});
+    await setDoc(doc(db, 'users', uid, 'tags', lower), { name: lower });
+    setYourTags(t => (t.some(x => x.id === lower) ? t : [...t, { id: lower, name: lower }]));
+  }, [uid]);
+
+  const leaveTag = useCallback(async (id: string) => {
+    if (!uid) return;
+    await deleteDoc(doc(db, 'tags', id, 'members', uid));
+    await deleteDoc(doc(db, 'users', uid, 'tags', id));
+    setYourTags(t => t.filter(x => x.id !== id));
+  }, [uid]);
+
+  const loadYourTags = useCallback(async () => {
+    if (!uid) return;
+    const snap = await getDocs(collection(db, 'users', uid, 'tags'));
+    const arr: TagInfo[] = [];
+    for (const d of snap.docs) {
+      const t = await getDoc(doc(db, 'tags', d.id));
+      if (t.exists()) {
+        arr.push({ id: d.id, ...(t.data() as Record<string, unknown>) } as TagInfo);
+      } else {
+        arr.push({ id: d.id, name: d.id });
+      }
+    }
+    setYourTags(arr);
+  }, [uid]);
+
+  const loadTrending = useCallback(async () => {
+    if (loadingTrend || !trendMore) return;
+    setLoadingTrend(true);
+    let q = query(collection(db, 'tags'), orderBy('memberCount', 'desc'), limit(12));
+    if (trendCursor) q = query(q, startAfter(trendCursor));
+    const snap = await getDocs(q);
+    const arr = snap.docs.map(d => ({ id: d.id, ...(d.data() as Record<string, unknown>) } as TagInfo));
+    setTrending(t => [...t, ...arr]);
+    setTrendCursor(snap.docs[snap.docs.length - 1] || null);
+    setTrendMore(snap.size === 12);
+    setLoadingTrend(false);
+  }, [trendCursor, trendMore, loadingTrend]);
+
+  const loadFeatured = useCallback(async () => {
+    if (loadingFeat || !featMore) return;
+    setLoadingFeat(true);
+    let q = query(collection(db, 'tags'), where('isFeatured', '==', true), orderBy('memberCount', 'desc'), limit(12));
+    if (featCursor) q = query(q, startAfter(featCursor));
+    const snap = await getDocs(q);
+    const arr = snap.docs.map(d => ({ id: d.id, ...(d.data() as Record<string, unknown>) } as TagInfo));
+    setFeatured(f => [...f, ...arr]);
+    setFeatCursor(snap.docs[snap.docs.length - 1] || null);
+    setFeatMore(snap.size === 12);
+    setLoadingFeat(false);
+  }, [featCursor, featMore, loadingFeat]);
+
+  const searchTags = useCallback(async () => {
+    if (!debounced) { setSearchResults([]); return; }
+    const term = debounced.toLowerCase();
+    const q = query(
+      collection(db, 'tags'),
+      orderBy('name'),
+      startAfter(term),
+      limit(5)
+    );
+    const snap = await getDocs(q);
+    const arr = snap.docs
+      .filter(d => d.id.startsWith(term))
+      .map(d => ({ id: d.id, ...(d.data() as Record<string, unknown>) } as TagInfo));
+    setSearchResults(arr);
+  }, [debounced]);
+
+  useEffect(() => { loadYourTags(); }, [loadYourTags]);
+  useEffect(() => { loadTrending(); }, [loadTrending]);
+  useEffect(() => { loadFeatured(); }, [loadFeatured]);
+  useEffect(() => { searchTags(); }, [searchTags]);
+
+  if (!uid) return <Spin />;
+
+  const renderTag = (tag: TagInfo) => {
+    const joined = yourTags.some(t => t.id === tag.id);
+    return (
+      <motion.div variants={cardVariants(reduce)} key={tag.id}>
+        <Card
+          className="glass-card"
+          hoverable
+          onClick={() => navigate(`/explore/${tag.id}`)}
+          actions={[
+            <Button
+              key="join"
+              type={joined ? 'default' : 'primary'}
+              onClick={e => {
+                e.stopPropagation();
+                if (joined) {
+                  leaveTag(tag.id);
+                } else {
+                  joinTag(tag.id);
+                }
+              }}
+            >
+              {joined ? 'Leave' : 'Join'}
+            </Button>,
+          ]}
+        >
+          <Card.Meta
+            title={`#${tag.name}`}
+            description={
+              <span>
+                <AntTag style={{ marginRight: 8 }}>{tag.type || 'tag'}</AntTag>
+                {tag.memberCount ?? 0} members
+              </span>
+            }
+          />
+        </Card>
+      </motion.div>
+    );
+  };
+
+  return (
+    <Card title="Explore" className="glass-card" style={{ margin: '2rem' }}>
+      <Input
+        placeholder="Search tags"
+        value={search}
+        onChange={e => setSearch(e.target.value)}
+        onPressEnter={() => {
+          if (searchResults[0]) navigate(`/explore/${searchResults[0].id}`);
+        }}
+        style={{ marginBottom: 16 }}
+      />
+      {search && searchResults.length > 0 && (
+        <List
+          bordered
+          style={{ marginBottom: 16 }}
+          dataSource={searchResults}
+          renderItem={t => (
+            <List.Item onClick={() => navigate(`/explore/${t.id}`)} style={{ cursor: 'pointer' }}>
+              #{t.name}
+            </List.Item>
+          )}
+        />
+      )}
+      <h3>Your Tags</h3>
+      <motion.div variants={{ show: { transition: { staggerChildren: m.durations.stagger } } }} initial="show" animate="show">
+        <List
+          grid={{ gutter: 16, xs: 1, sm: 2, md: 3, lg: 4 }}
+          dataSource={yourTags}
+          renderItem={t => <List.Item>{renderTag(t)}</List.Item>}
+        />
+      </motion.div>
+      <h3>Trending Tags</h3>
+      <motion.div variants={{ show: { transition: { staggerChildren: m.durations.stagger } } }} initial="show" animate="show">
+        <List
+          grid={{ gutter: 16, xs: 1, sm: 2, md: 3, lg: 4 }}
+          dataSource={trending}
+          renderItem={t => <List.Item>{renderTag(t)}</List.Item>}
+        />
+        {trendMore && (
+          <div style={{ textAlign: 'center', marginTop: 8 }}>
+            <Button onClick={loadTrending} loading={loadingTrend}>Load more</Button>
+          </div>
+        )}
+      </motion.div>
+      <h3>Featured Tags</h3>
+      <motion.div variants={{ show: { transition: { staggerChildren: m.durations.stagger } } }} initial="show" animate="show">
+        <List
+          grid={{ gutter: 16, xs: 1, sm: 2, md: 3, lg: 4 }}
+          dataSource={featured}
+          renderItem={t => <List.Item>{renderTag(t)}</List.Item>}
+        />
+        {featMore && (
+          <div style={{ textAlign: 'center', marginTop: 8 }}>
+            <Button onClick={loadFeatured} loading={loadingFeat}>Load more</Button>
+          </div>
+        )}
+      </motion.div>
+    </Card>
+  );
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   FolderOpenOutlined,
   TeamOutlined,
   ContactsOutlined,
+  TagOutlined,
 } from '@ant-design/icons';
 
 export function Sidebar() {
@@ -35,6 +36,7 @@ export function Sidebar() {
     ['/parse', 'Validate XML', <FileSearchOutlined />],
     ['/files', 'Files', <FolderOpenOutlined />],
     ['/groups', 'Groups', <TeamOutlined />],
+    ['/explore', 'Explore', <TagOutlined />],
     ['/contacts', 'Contacts', <ContactsOutlined />],
   ] as const;
 

--- a/web/src/components/TagDetail.tsx
+++ b/web/src/components/TagDetail.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState, useCallback } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Card, List, Avatar, Button, Spin, Tag as AntTag } from 'antd';
+import { useAuthState } from 'react-firebase-hooks/auth';
+import { collection, getDocs, doc, getDoc, setDoc, deleteDoc, type DocumentData } from 'firebase/firestore';
+import { auth, db } from '../lib/firebase';
+import { motion, useReducedMotion } from 'framer-motion';
+import { cardVariants, motion as m } from '../theme/motion';
+
+interface TagInfo {
+  id: string;
+  name: string;
+  type?: string;
+  memberCount?: number;
+}
+
+interface MemberInfo {
+  id: string;
+  displayName?: string;
+  photoURL?: string;
+  pronouns?: string;
+}
+
+export function TagDetail() {
+  const { tagId } = useParams();
+  const navigate = useNavigate();
+  const [user] = useAuthState(auth);
+  const uid = user?.uid;
+  const reduce = useReducedMotion() ?? false;
+
+  const [tag, setTag] = useState<TagInfo | null>(null);
+  const [members, setMembers] = useState<MemberInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const joined = members.some(m => m.id === uid);
+
+  const join = useCallback(async () => {
+    if (!uid || !tagId) return;
+    await setDoc(doc(db, 'tags', tagId, 'members', uid), {});
+    await setDoc(doc(db, 'users', uid, 'tags', tagId), { name: tagId });
+  }, [uid, tagId]);
+
+  const leave = useCallback(async () => {
+    if (!uid || !tagId) return;
+    await deleteDoc(doc(db, 'tags', tagId, 'members', uid));
+    await deleteDoc(doc(db, 'users', uid, 'tags', tagId));
+  }, [uid, tagId]);
+
+  useEffect(() => {
+    (async () => {
+      if (!tagId) return;
+      const t = await getDoc(doc(db, 'tags', tagId));
+      if (t.exists()) setTag({ id: t.id, ...(t.data() as Record<string, unknown>) } as TagInfo);
+      const snap = await getDocs(collection(db, 'tags', tagId, 'members'));
+      const arr: MemberInfo[] = [];
+      for (const d of snap.docs) {
+        const u = await getDoc(doc(db, 'users', d.id));
+        if (u.exists()) arr.push({ id: d.id, ...(u.data() as DocumentData) });
+      }
+      setMembers(arr);
+      setLoading(false);
+    })();
+  }, [tagId]);
+
+  if (!uid) return <Spin />;
+  if (loading || !tag) return <Spin />;
+
+  return (
+    <Card
+      title={`#${tag.name}`}
+      className="glass-card"
+      style={{ margin: '2rem' }}
+      extra={<Button onClick={() => navigate('/explore')}>Back</Button>}
+      actions={[
+        <Button key="join" type={joined ? 'default' : 'primary'} onClick={joined ? leave : join}>
+          {joined ? 'Leave' : 'Join'}
+        </Button>,
+      ]}
+    >
+      <p style={{ marginBottom: 16 }}>
+        <AntTag style={{ marginRight: 8 }}>{tag.type || 'tag'}</AntTag>
+        {tag.memberCount ?? members.length} members
+      </p>
+      <motion.div variants={{ show: { transition: { staggerChildren: m.durations.stagger } } }} initial="show" animate="show">
+        <List
+          grid={{ gutter: 16, xs: 1, sm: 2, md: 3, lg: 4 }}
+          dataSource={members}
+          renderItem={memb => (
+            <motion.div variants={cardVariants(reduce)} key={memb.id}>
+              <List.Item>
+                <Card className="glass-card" hoverable>
+                  <Card.Meta
+                    avatar={<Avatar src={memb.photoURL} />}
+                    title={memb.displayName}
+                    description={memb.pronouns}
+                  />
+                </Card>
+              </List.Item>
+            </motion.div>
+          )}
+        />
+      </motion.div>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- remove tag management UI from account page
- add new Explore and TagDetail pages for browsing tags
- link Explore in the sidebar and routing

## Testing
- `pnpm install`
- `npm run lint`
- `npm run build`
- `firebase deploy --only hosting` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a45206e48327b336cb7f08bf46ed