### PR TITLE
Add sign out and update link device modal

### DIFF
--- a/web/src/components/LinkDeviceModal.tsx
+++ b/web/src/components/LinkDeviceModal.tsx
@@ -44,13 +44,23 @@ export function LinkDeviceModal() {
         <Button
           className="link-device-btn"
           aria-label="Link Device"
-
-          type="primary"
-          shape="circle"
+          type="default"
           icon={<MobileOutlined />}
           onClick={() => setOpen(true)}
-          style={{ position: 'fixed', bottom: '2rem', right: '2rem', zIndex: 1000 }}
-        />
+          style={{
+            position: 'fixed',
+            bottom: '2rem',
+            right: '2rem',
+            zIndex: 1000,
+            backgroundColor: '#000',
+            color: '#fff',
+            fontWeight: 600,
+            padding: '0.75rem 1.5rem',
+            borderColor: '#000',
+          }}
+        >
+          Link Phone
+        </Button>
       </Tooltip>
       <Modal
         className="glass-modal"
@@ -69,16 +79,18 @@ export function LinkDeviceModal() {
         transitionName="fade-scale"
         maskTransitionName="fade"
       >
-        {error && (
-          <Alert
-            type="error"
-            message={error}
-            action={<Button size="small" onClick={fetchToken}>Retry</Button>}
-            style={{ marginBottom: 8 }}
-          />
-        )}
-        <div id="link-device-desc">
-          <Devices linkToken={token ?? undefined} />
+        <div style={{ maxHeight: '70vh', overflowY: 'auto', padding: '1rem' }}>
+          {error && (
+            <Alert
+              type="error"
+              message={error}
+              action={<Button size="small" onClick={fetchToken}>Retry</Button>}
+              style={{ marginBottom: 8 }}
+            />
+          )}
+          <div id="link-device-desc">
+            <Devices linkToken={token ?? undefined} />
+          </div>
         </div>
       </Modal>
     </>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useNavigate } from 'react-router-dom';
 import { Button, Drawer, Grid } from 'antd';
+import { signOut } from 'firebase/auth';
+import { auth } from '../lib/firebase';
 import {
   MenuOutlined,
   MenuFoldOutlined,
@@ -16,6 +18,7 @@ import {
 export function Sidebar() {
   const screens = Grid.useBreakpoint();
   const isMobile = !screens.md;
+  const navigate = useNavigate();
   const [collapsed, setCollapsed] = useState(
     () => localStorage.getItem('sidebarCollapsed') === 'true'
   );
@@ -56,6 +59,18 @@ export function Sidebar() {
           </NavLink>
         ))}
       </nav>
+      {/* Sign Out button pinned to bottom */}
+      <Button
+        className="signout-btn"
+        type="default"
+        danger
+        onClick={async () => {
+          await signOut(auth);
+          navigate('/account');
+        }}
+      >
+        Sign Out
+      </Button>
     </div>
   );
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -254,6 +254,11 @@ button:focus-visible {
   overflow-x: hidden;
 }
 
+.sidebar-content {
+  position: relative;
+  flex: 1;
+}
+
 .sidebar-link {
   display: flex;
   align-items: center;
@@ -327,6 +332,25 @@ button:focus-visible {
 .ant-modal-close:focus-visible,
 .link-device-btn:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
+}
+
+.link-device-btn {
+  background: #000;
+  color: #fff;
+  font-weight: 600;
+  padding: 0.75rem 1.5rem;
+  border-color: #000;
+}
+.link-device-btn:hover {
+  color: #fff;
+  background: #000;
+  box-shadow: 0 0 0 2px #000;
+}
+
+.signout-btn {
+  position: absolute;
+  bottom: 1rem;
+  width: calc(100% - 2rem);
 }
 
 


### PR DESCRIPTION
## Summary
- add Sign Out button to sidebar bottom
- restyle Link Phone trigger button
- limit Link Device modal height to avoid overflow

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68641c3ea09c8327874100ef70ef3e68