### PR TITLE
Add sign out and update link device modal

### DIFF
--- a/web/src/components/Devices.tsx
+++ b/web/src/components/Devices.tsx
@@ -174,9 +174,12 @@ export function Devices({ linkToken }: { linkToken?: string }) {
   return (
     <Card title="Linked Devices" className="glass-card" style={{ margin: '2rem', ...glassStyle }}>
       <Row gutter={[16, 16]}>
-        <Col xs={24} style={{ textAlign: 'center' }}>
-          <h2 style={{ marginBottom: '1rem' }}>Scan to Link Device</h2>
-          <canvas ref={canvasRef} />
+        <Col xs={24}>
+          {/* Ensure barcode fits without clipping */}
+          <div className="barcode-wrapper">
+            <h2 style={{ marginBottom: '1rem' }}>Scan to Link Device</h2>
+            <canvas ref={canvasRef} />
+          </div>
         </Col>
       </Row>
       <Row style={{ marginTop: '2rem' }}>

--- a/web/src/components/LinkDeviceModal.tsx
+++ b/web/src/components/LinkDeviceModal.tsx
@@ -41,16 +41,27 @@ export function LinkDeviceModal() {
   return (
     <>
       <Tooltip title="Link Device">
+        {/* Restyled Link Phone trigger button */}
         <Button
           className="link-device-btn"
           aria-label="Link Device"
-
-          type="primary"
-          shape="circle"
+          type="default"
           icon={<MobileOutlined />}
           onClick={() => setOpen(true)}
-          style={{ position: 'fixed', bottom: '2rem', right: '2rem', zIndex: 1000 }}
-        />
+          style={{
+            position: 'fixed',
+            bottom: '2rem',
+            right: '2rem',
+            zIndex: 1000,
+            backgroundColor: '#000',
+            color: '#fff',
+            fontWeight: 600,
+            padding: '0.75rem 1.5rem',
+            borderColor: '#000',
+          }}
+        >
+          Link Phone
+        </Button>
       </Tooltip>
       <Modal
         className="glass-modal"
@@ -69,16 +80,19 @@ export function LinkDeviceModal() {
         transitionName="fade-scale"
         maskTransitionName="fade"
       >
-        {error && (
-          <Alert
-            type="error"
-            message={error}
-            action={<Button size="small" onClick={fetchToken}>Retry</Button>}
-            style={{ marginBottom: 8 }}
-          />
-        )}
-        <div id="link-device-desc">
-          <Devices linkToken={token ?? undefined} />
+        {/* Wrap modal content to prevent overflow */}
+        <div style={{ maxHeight: '70vh', overflowY: 'auto', padding: '1rem' }}>
+          {error && (
+            <Alert
+              type="error"
+              message={error}
+              action={<Button size="small" onClick={fetchToken}>Retry</Button>}
+              style={{ marginBottom: 8 }}
+            />
+          )}
+          <div id="link-device-desc">
+            <Devices linkToken={token ?? undefined} />
+          </div>
         </div>
       </Modal>
     </>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useNavigate } from 'react-router-dom';
 import { Button, Drawer, Grid } from 'antd';
+import { signOut } from 'firebase/auth';
 import {
   MenuOutlined,
   MenuFoldOutlined,
@@ -11,11 +12,14 @@ import {
   TeamOutlined,
   ContactsOutlined,
   TagOutlined,
+  LogoutOutlined,
 } from '@ant-design/icons';
+import { auth } from '../lib/firebase';
 
 export function Sidebar() {
   const screens = Grid.useBreakpoint();
   const isMobile = !screens.md;
+  const navigate = useNavigate();
   const [collapsed, setCollapsed] = useState(
     () => localStorage.getItem('sidebarCollapsed') === 'true'
   );
@@ -56,6 +60,18 @@ export function Sidebar() {
           </NavLink>
         ))}
       </nav>
+      {/* Sign Out button pinned to bottom */}
+      <Button
+        className="sidebar-link signout-btn"
+        type="text"
+        icon={<LogoutOutlined />}
+        onClick={async () => {
+          await signOut(auth);
+          navigate('/account');
+        }}
+      >
+        <span className="label">Sign Out</span>
+      </Button>
     </div>
   );
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -254,6 +254,11 @@ button:focus-visible {
   overflow-x: hidden;
 }
 
+.sidebar-content {
+  position: relative;
+  flex: 1;
+}
+
 .sidebar-link {
   display: flex;
   align-items: center;
@@ -327,6 +332,49 @@ button:focus-visible {
 .ant-modal-close:focus-visible,
 .link-device-btn:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
+}
+
+/* Restyled Link Phone trigger button */
+.link-device-btn {
+  background: #000;
+  color: #fff;
+  font-weight: 600;
+  padding: 0.75rem 1.5rem;
+  border-color: #000;
+}
+.link-device-btn:hover {
+  color: #fff;
+  background: #000;
+  box-shadow: 0 0 0 2px #000;
+}
+
+/* Sign Out sidebar button styles */
+.signout-btn {
+  position: absolute;
+  bottom: 1rem;
+  width: calc(100% - 2rem);
+  background: rgba(255, 255, 255, 0.4);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: 0.5rem;
+  transition: background-color 0.2s var(--ease);
+}
+.signout-btn:hover {
+  background: rgba(255, 255, 255, 0.55);
+}
+body[data-theme='dark'] .signout-btn {
+  background: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+
+/* Ensure PDF417 barcode fits within modal */
+.barcode-wrapper {
+  overflow-x: auto;
+  text-align: center;
+}
+.barcode-wrapper canvas {
+  max-width: 100%;
 }
 
 


### PR DESCRIPTION
## Summary
- add Sign Out button at sidebar bottom with glassmorphic style
- hide Sign Out text when sidebar is collapsed
- restyle Link Phone trigger button and constrain modal height
- ensure PDF417 barcode fits without clipping

## Testing
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68641c3ea09c8327874100ef70ef3e68