### PR TITLE
Apply glass style tokens

### DIFF
--- a/web/src/components/ContactsOld.tsx
+++ b/web/src/components/ContactsOld.tsx
@@ -65,7 +65,7 @@ export function Contacts() {
   };
 
   const glassStyle = {
-    borderRadius: '1.5rem',
+    borderRadius: 'var(--glass-radius)',
   } as const;
 
   return (

--- a/web/src/components/Devices.tsx
+++ b/web/src/components/Devices.tsx
@@ -169,7 +169,7 @@ export function Devices({ linkToken }: { linkToken?: string }) {
     }
   };
 
-  const glassStyle = { borderRadius: '1.5rem' } as const;
+  const glassStyle = { borderRadius: 'var(--glass-radius)' } as const;
 
   return (
     <Card title="Linked Devices" className="glass-card" style={{ margin: '2rem', ...glassStyle }}>

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -67,7 +67,7 @@ export function Home() {
   };
 
   return (
-    <Card title="Sign In" className="glass-card" style={{ margin: '2rem', borderRadius: '1.5rem' }}>
+    <Card title="Sign In" className="glass-card" style={{ margin: '2rem', borderRadius: 'var(--glass-radius)' }}>
       <Row gutter={[16,16]}>
         <Col span={24}>
           <Button

--- a/web/src/components/LinkPhone.tsx
+++ b/web/src/components/LinkPhone.tsx
@@ -2,7 +2,7 @@ import { Card } from 'antd';
 
 export function LinkPhone() {
   return (
-    <Card title="Link Phone" style={{ margin: '2rem', borderRadius: '1.5rem' }}>
+    <Card title="Link Phone" style={{ margin: '2rem', borderRadius: 'var(--glass-radius)' }}>
       {/* TODO: list of uploaded/parsed YAML files */}
     </Card>
   );

--- a/web/src/components/UploadValidate.tsx
+++ b/web/src/components/UploadValidate.tsx
@@ -9,12 +9,12 @@ import { saveAs } from "file-saver";
 import { auth, db } from "../lib/firebase";
 import { addDoc, collection, serverTimestamp } from "firebase/firestore";
 
-// Glassmorphic card style
+// Glassmorphic card style using global tokens
 const glassStyle: CSSProperties = {
-  background: 'rgba(255,255,255,0.6)',
-  backdropFilter: 'blur(8px)',
-  borderRadius: '1.5rem',
-  boxShadow: '0 8px 32px rgba(0,0,0,0.125)',
+  background: 'var(--glass-bg-heavy)',
+  backdropFilter: 'blur(var(--glass-blur-heavy))',
+  borderRadius: 'var(--glass-radius)',
+  boxShadow: 'var(--glass-shadow-heavy)',
   height: '100%',
 };
 

--- a/web/src/glass-overrides.css
+++ b/web/src/glass-overrides.css
@@ -1,0 +1,36 @@
+/* Cards and modals */
+.ant-card,
+.ant-modal-content {
+  background: var(--glass-bg-heavy) !important;
+  backdrop-filter: blur(var(--glass-blur-heavy)) !important;
+  box-shadow: var(--glass-shadow-heavy) !important;
+  border-radius: var(--glass-radius) !important;
+}
+
+/* Inputs, textareas, selects */
+.ant-input,
+.ant-input-affix-wrapper,
+.ant-textarea,
+.ant-select-selector {
+  background: var(--glass-bg-heavy) !important;
+  backdrop-filter: blur(var(--glass-blur-heavy)) !important;
+  box-shadow: inset var(--glass-shadow-heavy) !important;
+  border: 1px solid rgba(255, 255, 255, 0.5) !important;
+  border-radius: var(--glass-radius) !important;
+}
+
+/* Primary & default buttons */
+.ant-btn-primary,
+.ant-btn-default {
+  background: var(--glass-bg-heavy) !important;
+  backdrop-filter: blur(var(--glass-blur-heavy)) !important;
+  box-shadow: var(--glass-shadow-heavy) !important;
+  border: 1px solid rgba(255, 255, 255, 0.5) !important;
+  border-radius: var(--glass-radius) !important;
+  color: #282828 !important;
+}
+/* On hover/active keep same glass, maybe intensify shadow */
+.ant-btn-primary:hover,
+.ant-btn-default:hover {
+  box-shadow: 0 12px 48px rgba(0,0,0,0.25) !important;
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -6,6 +6,12 @@
   --accent: #70C73C;
   --ease: cubic-bezier(0.4, 0, 0.2, 1);
 
+  /* Global glass tokens */
+  --glass-bg-heavy: rgba(255, 255, 255, 0.4);
+  --glass-blur-heavy: 16px;
+  --glass-shadow-heavy: 0 8px 32px rgba(0, 0, 0, 0.2);
+  --glass-radius: 1.5rem;
+
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
@@ -157,10 +163,10 @@ button:focus-visible {
 
 /* Glass card base */
 .glass-card {
-  background: rgba(255, 255, 255, 0.4);
-  backdrop-filter: blur(12px);
-  border-radius: 1.5rem;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  background: var(--glass-bg-heavy);
+  backdrop-filter: blur(var(--glass-blur-heavy));
+  border-radius: var(--glass-radius);
+  box-shadow: var(--glass-shadow-heavy);
   transition: all 250ms;
 }
 
@@ -323,10 +329,10 @@ button:focus-visible {
 }
 
 .glass-modal .ant-modal-content {
-  background: rgba(255, 255, 255, 0.4);
-  backdrop-filter: blur(12px);
-  border-radius: 1.5rem;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  background: var(--glass-bg-heavy);
+  backdrop-filter: blur(var(--glass-blur-heavy));
+  border-radius: var(--glass-radius);
+  box-shadow: var(--glass-shadow-heavy);
 }
 
 .ant-modal-close:focus-visible,

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";
+import "antd/dist/reset.css";
 import "./index.css";
+import "./glass-overrides.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/web/src/pages/AccountLanding.tsx
+++ b/web/src/pages/AccountLanding.tsx
@@ -130,14 +130,7 @@ export function AccountLanding() {
         <Col xs={24} md={12} className="landing-side">
           <Card
             className="glass-card landing-card"
-            style={{
-              width: '100%',
-              height: '100%',
-              padding: '2rem',
-              borderRadius: '1.5rem',
-              backdropFilter: 'blur(8px)',
-              background: 'rgba(255,255,255,0.6)',
-            }}
+            style={{ height: '100%' }}
           >
 
             <Row justify="space-between" align="middle" style={{ marginBottom: '1rem' }}>


### PR DESCRIPTION
## Summary
- define reusable glass tokens in index.css
- add AntD card, modal and control overrides
- import antd reset and overrides stylesheet in entry
- update inline glass styles to use CSS variables

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686426ab942c8327a7d739c13b948784