### PR TITLE
Standardize glass theme

### DIFF
--- a/web/src/components/UploadValidate.tsx
+++ b/web/src/components/UploadValidate.tsx
@@ -9,9 +9,9 @@ import { saveAs } from "file-saver";
 import { auth, db } from "../lib/firebase";
 import { addDoc, collection, serverTimestamp } from "firebase/firestore";
 
-// Glassmorphic card style
+// Glassmorphic card style using global token
 const glassStyle: CSSProperties = {
-  background: 'rgba(255,255,255,0.6)',
+  background: 'var(--glass-bg)',
   backdropFilter: 'blur(8px)',
   borderRadius: '1.5rem',
   boxShadow: '0 8px 32px rgba(0,0,0,0.125)',

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -157,10 +157,12 @@ button:focus-visible {
 
 /* Glass card base */
 .glass-card {
-  background: rgba(255, 255, 255, 0.4);
+  /* Use global glass token for card background */
+  background: var(--glass-bg);
   backdrop-filter: blur(12px);
   border-radius: 1.5rem;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  color: var(--glass-text);
   transition: all 250ms;
 }
 
@@ -230,7 +232,8 @@ button:focus-visible {
   left: 0;
   bottom: 0;
   width: var(--sidebar-width);
-  background: rgba(255, 255, 255, 0.8);
+  /* Sidebar uses the shared glass background */
+  background: var(--glass-bg);
   backdrop-filter: blur(12px);
   box-shadow: 2px 0 12px rgba(0, 0, 0, 0.15);
   border-right: 1px solid rgba(255, 255, 255, 0.6);
@@ -323,10 +326,12 @@ button:focus-visible {
 }
 
 .glass-modal .ant-modal-content {
-  background: rgba(255, 255, 255, 0.4);
+  /* Modal glass background matches cards */
+  background: var(--glass-bg);
   backdrop-filter: blur(12px);
   border-radius: 1.5rem;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  color: var(--glass-text);
 }
 
 .ant-modal-close:focus-visible,
@@ -355,14 +360,17 @@ button:focus-visible {
   position: absolute;
   bottom: 1rem;
   width: calc(100% - 2rem);
-  background: rgba(255, 255, 255, 0.4);
+  /* Button uses control glass token */
+  background: var(--glass-control-bg);
   backdrop-filter: blur(12px);
   border: 1px solid rgba(255, 255, 255, 0.6);
   border-radius: 0.5rem;
+  color: var(--glass-text);
   transition: background-color 0.2s var(--ease);
 }
-.signout-btn:hover {
-  background: rgba(255, 255, 255, 0.55);
+.signout-btn:hover,
+.signout-btn:focus {
+  background: rgba(255, 255, 255, 0.63);
 }
 body[data-theme='dark'] .signout-btn {
   background: rgba(0, 0, 0, 0.4);

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";
 import "./index.css";
+import "./theme/glass.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/web/src/pages/AccountLanding.tsx
+++ b/web/src/pages/AccountLanding.tsx
@@ -136,7 +136,8 @@ export function AccountLanding() {
               padding: '2rem',
               borderRadius: '1.5rem',
               backdropFilter: 'blur(8px)',
-              background: 'rgba(255,255,255,0.6)',
+              // Use shared glass token for consistency
+              background: 'var(--glass-bg)',
             }}
           >
 

--- a/web/src/theme/glass.css
+++ b/web/src/theme/glass.css
@@ -1,0 +1,59 @@
+:root {
+  /* Global glass tokens */
+  --glass-bg: rgba(255, 255, 255, 0.8);
+  --glass-control-bg: rgba(255, 255, 255, 0.6);
+  --glass-text: #282828;
+}
+
+/* Apply glass tokens to Ant Design components */
+.glass-card,
+.sidebar,
+.glass-modal .ant-modal-content {
+  background: var(--glass-bg);
+  color: var(--glass-text);
+}
+
+.ant-btn:not(.ant-btn-primary),
+.ant-input,
+.ant-input-affix-wrapper,
+.ant-select-selector,
+.ant-picker,
+.ant-input-number,
+.ant-input-number-input {
+  background: var(--glass-control-bg);
+  color: var(--glass-text);
+  backdrop-filter: blur(12px);
+}
+
+.ant-input::placeholder,
+.ant-input-affix-wrapper input::placeholder {
+  color: var(--glass-text);
+  opacity: 0.7;
+}
+
+/* Hover & focus lighten */
+.ant-btn:not(.ant-btn-primary):hover,
+.ant-btn:not(.ant-btn-primary):focus,
+.ant-input:hover,
+.ant-input:focus,
+.ant-input-affix-wrapper:hover,
+.ant-input-affix-wrapper:focus-within,
+.ant-select-selector:hover,
+.ant-select-selector:focus,
+.ant-picker:hover,
+.ant-picker-focused,
+.ant-input-number:hover,
+.ant-input-number-focused {
+  background: rgba(255, 255, 255, 0.63); /* --glass-control-bg + 5% */
+}
+
+/* Signout button inherits as glass-button */
+.signout-btn {
+  background: var(--glass-control-bg);
+  color: var(--glass-text);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+}
+.signout-btn:hover,
+.signout-btn:focus {
+  background: rgba(255, 255, 255, 0.63);
+}


### PR DESCRIPTION
## Summary
- add global glass tokens in `glass.css`
- apply `--glass-bg` to cards, sidebar and modal
- use `--glass-control-bg` for sign out button
- import glass theme globally
- reference glass token in landing page and upload validation styles

## Testing
- `npm run build`
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864689e9aec832793a5f1a26d329712