### PR TITLE
Improve group invites and member details

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -388,4 +388,9 @@ body[data-theme='dark'] .signout-btn {
 
 }
 
+.group-card:hover {
+  background: rgba(255, 255, 255, 0.1);
+  cursor: pointer;
+}
+
 


### PR DESCRIPTION
## Summary
- surface group invites on the groups page
- show Manage button and hover highlight for group cards
- add invite flow to group detail page
- render member pronouns and tags
- style group cards

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686475ca7ab8832790cf464e5f64b071