### PR TITLE
Implement group announcements and UX fixes

### DIFF
--- a/web/src/components/SendFileModal.tsx
+++ b/web/src/components/SendFileModal.tsx
@@ -1,0 +1,29 @@
+import { Modal, Button } from 'antd';
+import { useState } from 'react';
+
+interface Props {
+  groupId: string;
+  onClose: () => void;
+}
+
+export function SendFileModal({ groupId, onClose }: Props) {
+  const [open, setOpen] = useState(true);
+
+  const handleClose = () => {
+    setOpen(false);
+    onClose();
+  };
+
+  return (
+    <Modal
+      className="glass-modal"
+      open={open}
+      title="Assign Parts / Send File"
+      onCancel={handleClose}
+      footer={<Button onClick={handleClose}>Close</Button>}
+      maskStyle={{ backdropFilter: 'blur(8px)', backgroundColor: 'rgba(255,255,255,0.125)' }}
+    >
+      <p>Feature coming soon.</p>
+    </Modal>
+  );
+}

--- a/web/src/lib/profile.ts
+++ b/web/src/lib/profile.ts
@@ -1,0 +1,14 @@
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from './firebase';
+
+export interface Profile {
+  displayName?: string;
+  pronouns?: string;
+  photoURL?: string;
+}
+
+export async function fetchProfile(uid: string): Promise<Profile> {
+  const ref = doc(db, 'users', uid, 'profile');
+  const snap = await getDoc(ref);
+  return snap.exists() ? (snap.data() as Profile) : {};
+}


### PR DESCRIPTION
## Summary
- add helper for fetching user profiles
- show group announcements tab with rich-text editor
- gate settings and invite tabs by role and use URL-based tab state
- display inviter details and invite date
- allow owners/mods to launch send files modal on group cards and detail page
- guard delete group action behind safety latch

## Testing
- `pnpm exec tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68647994b5f8832781ab144aaa0ad193