### PR TITLE
Improve group deletion & invites

### DIFF
--- a/web/src/components/Account.tsx
+++ b/web/src/components/Account.tsx
@@ -239,12 +239,14 @@ export function Account() {
     const ref = collection(db, 'users', uid, 'groups');
     const unsub = onSnapshot(ref, async snap => {
       const ids = snap.docs.map(d => d.id);
-      const results: Array<{ id: string; name: string }> = [];
+      const results: Array<{ id: string; name: string; isDeleted?: boolean; deletedAt?: Timestamp }> = [];
       for (const id of ids) {
         const g = await getDoc(doc(db, 'groups', id));
         if (g.exists()) {
-          const data = g.data() as { name: string };
-          results.push({ id, name: data.name });
+          const data = g.data() as any;
+          const within = data.isDeleted && data.deletedAt && (Date.now() - data.deletedAt.toMillis() <= 15 * 24 * 60 * 60 * 1000);
+          if (data.isDeleted && !within) continue;
+          results.push({ id, name: within ? 'Group Deleted' : data.name, isDeleted: data.isDeleted, deletedAt: data.deletedAt });
         }
       }
       setGroups(results);
@@ -667,7 +669,8 @@ export function Account() {
         </Card>
         <Card title="My Ensembles" className="glass-card" style={{ marginTop: 16 }}>
           {groups.map(g => (
-            <Tag key={g.id} style={{ marginBottom: 4 }}>
+            // 4️⃣ Exclude or placeholder-render deleted groups
+            <Tag key={g.id} style={{ marginBottom: 4, opacity: g.isDeleted ? 0.5 : 1 }}>
               {g.name}
             </Tag>
           ))}


### PR DESCRIPTION
## Summary
- add soft delete fields to groups
- show deleted groups as placeholders
- invite users with group invite docs
- ensure owner membership exists
- filter deleted groups from account list
- schedule cloud function to purge old deletions

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68648dbb58ac8327b12ccfab94ff00c0