### PR TITLE
Add YAML upload helper

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -27,7 +27,8 @@
     "react-router-dom": "^6.30.1",
     "react-syntax-highlighter": "^15.6.1",
     "react-transition-group": "^4.4.5",
-    "framer-motion": "^11.0.0"
+    "framer-motion": "^11.0.0",
+    "yaml": "^2.3.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       react-transition-group:
         specifier: ^4.4.5
         version: 4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      yaml:
+        specifier: ^2.3.4
+        version: 2.8.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.29.0
@@ -95,7 +98,7 @@ importers:
         version: 4.4.12(@types/react@19.1.8)
       '@vitejs/plugin-react':
         specifier: ^4.5.2
-        version: 4.6.0(vite@7.0.0(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1))
+        version: 4.6.0(vite@7.0.0(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
@@ -134,7 +137,7 @@ importers:
         version: 8.35.0(eslint@9.30.0(jiti@2.4.2))(typescript@5.8.3)
       vite:
         specifier: ^7.0.0
-        version: 7.0.0(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1)
+        version: 7.0.0(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
 
 packages:
 
@@ -3641,6 +3644,11 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
+  yaml@2.8.0:
+    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -5078,7 +5086,7 @@ snapshots:
       '@typescript-eslint/types': 8.35.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react@4.6.0(vite@7.0.0(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1))':
+  '@vitejs/plugin-react@4.6.0(vite@7.0.0(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))':
     dependencies:
       '@babel/core': 7.27.7
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.27.7)
@@ -5086,7 +5094,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.19
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.0.0(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1)
+      vite: 7.0.0(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7605,7 +7613,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  vite@7.0.0(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1):
+  vite@7.0.0(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.6(picomatch@4.0.2)
@@ -7618,6 +7626,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.30.1
+      yaml: 2.8.0
 
   w3c-xmlserializer@4.0.0:
     dependencies:
@@ -7707,6 +7716,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@5.0.0: {}
+
+  yaml@2.8.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/web/src/components/UploadValidate.tsx
+++ b/web/src/components/UploadValidate.tsx
@@ -3,11 +3,12 @@ import { useDropzone } from "react-dropzone";
 import { parseUpload } from "../lib/api";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { materialLight } from "react-syntax-highlighter/dist/esm/styles/prism";
-import { Card, Button, Row, Col, Input, Switch, message, Alert, Spin } from "antd";
+import { Card, Button, Row, Col, Input, Switch, message, Alert, Spin, Tabs } from "antd";
 import { SunOutlined, MoonOutlined, CopyOutlined, DownloadOutlined } from "@ant-design/icons";
 import { saveAs } from "file-saver";
-import { auth, db } from "../lib/firebase";
-import { addDoc, collection, serverTimestamp } from "firebase/firestore";
+import { auth } from "../lib/firebase";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import { uploadYaml } from "../lib/api";
 
 // Glassmorphic card style using global token
 const glassStyle: CSSProperties = {
@@ -45,6 +46,8 @@ export function UploadValidate() {
 
   const [xmlText, setXmlText] = useState("");
   const [yaml, setYaml] = useState<string | null>(null);
+  const [parts, setParts] = useState<{ name: string; yaml: string }[]>([]);
+  const [activeTab, setActiveTab] = useState('full');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [filename, setFilename] = useState('out.yaml');
@@ -83,7 +86,30 @@ export function UploadValidate() {
         () => parseUpload(blob, filename, uid),
         3,
         500
-      );      setYaml(result);
+      );
+      setYaml(result);
+      // Split YAML into individual parts if applicable
+      try {
+        const events = parseYaml(result) as Array<any>;
+        const instruments = Array.from(
+          new Set(
+            events
+              .map((e: any) => (e.instruments ? e.instruments[0] : null))
+              .filter(Boolean)
+          )
+        ) as string[];
+        const partArr = instruments.map((inst) => ({
+          name: inst,
+          yaml: stringifyYaml(
+            events.filter((e: any) => (e.instruments || []).includes(inst))
+          ),
+        }));
+        setParts(partArr);
+      } catch (e) {
+        console.warn("Part split failed", e);
+        setParts([]);
+      }
+      setActiveTab('full');
       const duration = ((performance.now() - start) / 1000).toFixed(2);
       message.success(`Parsed in ${duration}s`, 3);
     } catch (err: unknown) {
@@ -117,25 +143,17 @@ export function UploadValidate() {
       message.error('No user signed in', 3);
       return;
     }
+    const selectedYaml = activeTab === 'full'
+      ? yaml
+      : parts.find(p => p.name === activeTab)?.yaml;
+    if (!selectedYaml) return;
+    const sendName = activeTab === 'full' ? filename : `${activeTab}.yaml`;
     try {
-      await addDoc(collection(db, 'users', uid, 'files'), {
-        title: filename,
-        yaml,
-        createdAt: serverTimestamp(),
-        size: yaml.length,
-        status: 'ready',
-      });
-      await addDoc(collection(db, 'users', uid, 'sent'), {
-        title: filename,
-        yaml,
-        createdAt: serverTimestamp(),
-        size: yaml.length,
-        status: 'ready',
-      });
-      message.success('Saved to My Files', 3);
+      await uploadYaml(selectedYaml, sendName, uid);
+      message.success(`Sent '${sendName}' to My Files`, 3);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      message.error(msg || 'Failed to save', 3);
+      message.error(msg || 'Failed to send', 3);
     }
   };
 
@@ -219,9 +237,39 @@ export function UploadValidate() {
               {yaml ? (
                 <>
                   <div style={{ flex: 1, overflow: 'auto' }}>
-                    <SyntaxHighlighter language="yaml" style={materialLight} customStyle={{ fontSize: '1.2rem' }}>
-                      {yaml}
-                    </SyntaxHighlighter>
+                    <Tabs
+                      destroyInactiveTabPane={false}
+                      activeKey={activeTab}
+                      onChange={setActiveTab}
+                      items={[
+                        {
+                          key: 'full',
+                          label: 'Full Score',
+                          children: (
+                            <SyntaxHighlighter
+                              language="yaml"
+                              style={materialLight}
+                              customStyle={{ fontSize: '1.2rem' }}
+                            >
+                              {yaml}
+                            </SyntaxHighlighter>
+                          ),
+                        },
+                        ...parts.map(p => ({
+                          key: p.name,
+                          label: p.name,
+                          children: (
+                            <SyntaxHighlighter
+                              language="yaml"
+                              style={materialLight}
+                              customStyle={{ fontSize: '1.2rem' }}
+                            >
+                              {p.yaml}
+                            </SyntaxHighlighter>
+                          ),
+                        })),
+                      ]}
+                    />
                   </div>
                   <div style={{ marginTop: '1rem', textAlign: 'right' }}>
                     <Input
@@ -230,20 +278,11 @@ export function UploadValidate() {
                       style={{ width: '60%', marginRight: '1rem', fontSize: '1.2rem' }}
                     />
                     <Button icon={<CopyOutlined />} onClick={handleCopy} style={{ marginRight: '0.5rem' }} />
-                    <Button icon={<DownloadOutlined />} onClick={handleDownload} />
+                    <Button icon={<DownloadOutlined />} onClick={handleDownload} style={{ marginRight: '0.5rem' }} />
+                    <Button type="primary" onClick={handleSendToFiles}>
+                      Send to My Files
+                    </Button>
                   </div>
-                  <Button
-                    type="primary"
-                    size="large"
-                    style={{
-                      backgroundColor: '#70C73C',
-                      borderRadius: '1rem',
-                      marginTop: '1rem',
-                    }}
-                    onClick={handleSendToFiles}
-                  >
-                    Send to My Files
-                  </Button>
                   </>
                 ) : (
                   <div style={{ textAlign: 'center', color: '#888', padding: '2rem', fontSize: '1.2rem' }}>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,9 +1,13 @@
+const FUNCTIONS_BASE_URL =
+  import.meta.env.VITE_PARSE_URL ||
+  `https://us-central1-${import.meta.env.VITE_FIREBASE_PROJECT_ID}.cloudfunctions.net`;
+
 export async function parseUpload(
   xmlBlob: Blob,
   filename: string,
   uid: string
 ): Promise<string> {
-  const url = `https://us-central1-${import.meta.env.VITE_FIREBASE_PROJECT_ID}.cloudfunctions.net/parseUpload`;
+  const url = `${FUNCTIONS_BASE_URL}/parseUpload`;
   console.log("📡 parseUpload calling", { url, filename, uid });
   const resp = await fetch(url, {
     method: "POST",
@@ -81,6 +85,26 @@ export async function removePeer(peerUid: string, fromUid: string): Promise<void
       Authorization: `Bearer ${fromUid}`,
     },
     body: JSON.stringify({ peerUid, fromUid }),
+  });
+  if (!resp.ok) {
+    throw new Error(await resp.text());
+  }
+}
+
+export async function uploadYaml(
+  yamlText: string,
+  filename: string,
+  uid: string,
+): Promise<void> {
+  const url = `${FUNCTIONS_BASE_URL}/parseUpload`;
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'text/yaml',
+      Authorization: `Bearer ${uid}`,
+      'X-File-Name': filename,
+    },
+    body: yamlText,
   });
   if (!resp.ok) {
     throw new Error(await resp.text());


### PR DESCRIPTION
## Summary
- introduce `uploadYaml` helper for sending YAML to parseUpload
- adjust Send to My Files button placement
- use `uploadYaml` in UploadValidate
- centralize Cloud Function URL with `FUNCTIONS_BASE_URL`

## Testing
- `pnpm test` in `web`
- `pnpm test` in `functions`


------
https://chatgpt.com/codex/tasks/task_e_68648f0ea6a083279bf9a1bc4d1d269a