### PR TITLE
feat(parse): tabbed parts view and direct send

### DIFF
--- a/web/src/components/UploadValidate.tsx
+++ b/web/src/components/UploadValidate.tsx
@@ -292,20 +292,19 @@ export function UploadValidate() {
                       style={{ width: '60%', marginRight: '1rem', fontSize: '1.2rem' }}
                     />
                     <Button icon={<CopyOutlined />} onClick={handleCopy} style={{ marginRight: '0.5rem' }} />
-                    <Button icon={<DownloadOutlined />} onClick={handleDownload} />
+                    <Button icon={<DownloadOutlined />} onClick={handleDownload} style={{ marginRight: '0.5rem' }} />
+                    <Button
+                      type="primary"
+                      size="large"
+                      style={{
+                        backgroundColor: '#70C73C',
+                        borderRadius: '1rem',
+                      }}
+                      onClick={handleSendToFiles}
+                    >
+                      Send to My Files
+                    </Button>
                   </div>
-                  <Button
-                    type="primary"
-                    size="large"
-                    style={{
-                      backgroundColor: '#70C73C',
-                      borderRadius: '1rem',
-                      marginTop: '1rem',
-                    }}
-                    onClick={handleSendToFiles}
-                  >
-                    Send to My Files
-                  </Button>
                   </>
                 ) : (
                   <div style={{ textAlign: 'center', color: '#888', padding: '2rem', fontSize: '1.2rem' }}>


### PR DESCRIPTION
## Summary
- recognize multiple parts in the returned YAML
- show Full Score/part tabs with YAML views
- allow uploading selected YAML via **Send to My Files** button
- keep button aligned with other controls

## Testing
- `pnpm --filter web run build`
- `cargo test --manifest-path parser/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6864a096c0448327a187787d135c00b6