### PR TITLE
Implement handle-based group invitations

### DIFF
--- a/web/src/components/GroupDetail.tsx
+++ b/web/src/components/GroupDetail.tsx
@@ -31,8 +31,6 @@ import {
   serverTimestamp,
 } from 'firebase/firestore';
 import { auth, db } from '../lib/firebase';
-import { useUserSearch } from '../hooks/useUserSearch';
-import type { UserInfo } from '../hooks/useFriends';
 import { toast } from '../lib/toast';
 import { SendFilesModal } from './SendFilesModal';
 
@@ -84,8 +82,7 @@ export function GroupDetail() {
 
   const [search, setSearch] = useState('');
   const [inviteTerm, setInviteTerm] = useState('');
-  const results = useUserSearch(inviteTerm);
-  const [inviting, setInviting] = useState<string | null>(null);
+  const [inviting, setInviting] = useState(false);
   const [sendOpen, setSendOpen] = useState(false);
   const [announceContent, setAnnounceContent] = useState('');
   const [posting, setPosting] = useState(false);
@@ -174,9 +171,7 @@ export function GroupDetail() {
     if (!groupId) return;
     const q = collection(db, 'groups', groupId, 'invites');
     const unsub = onSnapshot(q, snap => {
-      const arr = snap.docs
-        .map(d => ({ id: d.id, ...(d.data() as any) }))
-        .filter(i => i.status === 'pending');
+      const arr = snap.docs.map(d => ({ id: d.id, ...(d.data() as any) }));
       setSentInvites(arr);
     });
     return unsub;
@@ -216,37 +211,35 @@ export function GroupDetail() {
     await deleteDoc(doc(db, 'users', id, 'groups', groupId));
   };
 
-  const inviteUser = async (userInfo: UserInfo) => {
-    if (!groupId || !uid) return;
-    setInviting(userInfo.id);
+  const inviteUser = async () => {
+    if (!groupId || !uid || !inviteTerm.trim()) return;
+    const handle = inviteTerm.trim().replace(/^@+/, '').toLowerCase();
+    setInviting(true);
     try {
-      // 2️⃣ Invitations subcollection scaffolding
-      const gRef = await addDoc(collection(db, 'groups', groupId, 'invites'), {
-        inviterUid: uid,
-        inviteeEmailOrUid: inviteTerm,
-        inviteeUid: userInfo.id,
-        createdAt: serverTimestamp(),
-        status: 'pending',
-      });
-      await setDoc(doc(db, 'users', userInfo.id, 'invites', gRef.id), {
-        groupId,
-        invitedByUid: uid,
+      // Lookup target UID
+      const snap = await getDoc(doc(db, 'usernames', handle));
+      if (!snap.exists()) {
+        toast.error(`User '${handle}' not found.`);
+        return;
+      }
+      const targetUid = (snap.data() as { uid: string }).uid;
+      // Send invite to Firestore
+      await setDoc(doc(db, 'groups', groupId, 'invites', targetUid), {
+        invitedBy: uid,
         invitedAt: serverTimestamp(),
       });
-      toast.success(`Invitation sent to ${userInfo.displayName || userInfo.email}`);
+      toast.success(`Invitation sent to @${handle}`);
+      setInviteTerm('');
     } catch (e) {
       toast.error(`Could not send invite: ${(e as Error).message}`);
     } finally {
-      setInviting(null);
+      setInviting(false);
     }
   };
 
-  const revokeInvite = async (invId: string, inviteeUid?: string) => {
+  const revokeInvite = async (inviteeUid: string) => {
     if (!groupId) return;
-    await deleteDoc(doc(db, 'groups', groupId, 'invites', invId));
-    if (inviteeUid) {
-      await deleteDoc(doc(db, 'users', inviteeUid, 'invites', invId)).catch(() => {});
-    }
+    await deleteDoc(doc(db, 'groups', groupId, 'invites', inviteeUid));
   };
 
   const postAnnouncement = async () => {
@@ -391,51 +384,26 @@ export function GroupDetail() {
       animate="show"
     >
       <Input
-        placeholder="Add users by email or username…"
+        placeholder="Invite by handle…"
         style={{ marginBottom: 8 }}
         value={inviteTerm}
         onChange={e => setInviteTerm(e.target.value)}
+        onPressEnter={inviteUser}
+        disabled={inviting}
       />
-      {inviteTerm && (
-        <List
-          style={{ marginBottom: 8 }}
-          dataSource={results}
-          renderItem={u => (
-            <List.Item
-              actions={[
-                <Button
-                  key="inv"
-                  type="primary"
-                  loading={inviting === u.id}
-                  onClick={() => inviteUser(u)}
-                >
-                  Invite
-                </Button>,
-              ]}
-            >
-              <List.Item.Meta
-                avatar={<Avatar src={u.photoURL} />}
-                title={u.displayName || u.email}
-                description={`@${u.handle || ''}`}
-              />
-            </List.Item>
-          )}
-        />
-      )}
+      <Button type="primary" onClick={inviteUser} loading={inviting} style={{ marginBottom: 16 }}>
+        Invite
+      </Button>
       <List
         header="Pending Invites"
         dataSource={sentInvites}
         renderItem={inv => (
           <List.Item
-            actions={[
-              <Button key="rev" danger onClick={() => revokeInvite(inv.id, inv.inviteeUid)}>
-                Revoke
-              </Button>,
-            ]}
+            actions={[<Button key="rev" danger onClick={() => revokeInvite(inv.id)}>Revoke</Button>]}
           >
             <List.Item.Meta
-              title={inv.inviteeEmailOrUid}
-              description={inv.createdAt?.toDate().toLocaleDateString()}
+              title={`@${inv.id}`}
+              description={inv.invitedAt?.toDate().toLocaleDateString()}
             />
           </List.Item>
         )}

--- a/web/src/components/Groups.tsx
+++ b/web/src/components/Groups.tsx
@@ -17,11 +17,11 @@ import {
   setDoc,
   deleteDoc,
   query,
+  collectionGroup,
   where,
   serverTimestamp,
   getDoc,
-  updateDoc,
-  increment,
+  documentId,
   type Timestamp,
 } from 'firebase/firestore';
 
@@ -104,21 +104,30 @@ export function Groups() {
 
   useEffect(() => {
     if (!uid) return;
-    const q = collection(db, 'users', uid, 'invites');
+    const q = query(
+      collectionGroup(db, 'invites'),
+      where(documentId(), '==', uid),
+      where('invitedBy', '!=', uid),
+    );
     const unsub = onSnapshot(q, async snap => {
       const arr: Invite[] = [];
       for (const d of snap.docs) {
-        const data = d.data() as Omit<Invite, 'id'>;
-        const groupSnap = await getDoc(doc(db, 'groups', data.groupId));
+        const data = d.data() as { invitedBy: string; invitedAt: Timestamp };
+        const groupId = d.ref.parent.parent?.id;
+        if (!groupId) continue;
+        // Fetch group and inviter info
+        const groupSnap = await getDoc(doc(db, 'groups', groupId));
         const gData = groupSnap.exists() ? (groupSnap.data() as { name?: string }) : {};
         const groupName = gData.name ?? '';
-        const inviterSnap = await getDoc(doc(db, 'users', data.invitedByUid, 'profile'));
+        const inviterSnap = await getDoc(doc(db, 'users', data.invitedBy, 'profile'));
         const inviterData = inviterSnap.exists()
           ? (inviterSnap.data() as { displayName?: string; pronouns?: string; photoURL?: string })
           : {};
         arr.push({
           id: d.id,
-          ...data,
+          groupId,
+          invitedByUid: data.invitedBy,
+          invitedAt: data.invitedAt,
           groupName,
           inviterName: inviterData.displayName || 'Unknown',
           inviterPronouns: inviterData.pronouns || 'they/them',
@@ -176,11 +185,13 @@ export function Groups() {
   const acceptInvite = async (inv: Invite) => {
     if (!uid) return;
     try {
-      await deleteDoc(doc(db, 'users', uid, 'invites', inv.id));
-      await setDoc(doc(db, 'groups', inv.groupId, 'members', uid), { role: 'member' });
-      await setDoc(doc(db, 'users', uid, 'groups', inv.groupId), { role: 'member', joinedAt: serverTimestamp() });
-      await updateDoc(doc(db, 'groups', inv.groupId), { memberCount: increment(1) });
-      toast.success('Joined group');
+      // Accept invite: add membership then remove invite
+      await setDoc(doc(db, 'groups', inv.groupId, 'members', uid), {
+        role: 'member',
+        joinedAt: serverTimestamp(),
+      });
+      await deleteDoc(doc(db, 'groups', inv.groupId, 'invites', uid));
+      toast.success(`You've joined ${inv.groupName}.`);
     } catch (e) {
       toast.error((e as Error).message);
     }
@@ -189,8 +200,8 @@ export function Groups() {
   const declineInvite = async (inv: Invite) => {
     if (!uid) return;
     try {
-      await deleteDoc(doc(db, 'users', uid, 'invites', inv.id));
-      toast.info('Invite declined');
+      await deleteDoc(doc(db, 'groups', inv.groupId, 'invites', uid));
+      toast.info(`Invite to ${inv.groupName} declined.`);
     } catch (e) {
       toast.error((e as Error).message);
     }
@@ -200,7 +211,7 @@ export function Groups() {
   return (
     <>
       {invites.length > 0 && (
-        <Card title="Group Invites" className="glass-card" style={{ margin: '2rem' }}>
+        <Card title="Invitations" className="glass-card" style={{ margin: '2rem' }}>
           <List
             dataSource={invites}
             renderItem={inv => (


### PR DESCRIPTION
## Summary
- look up usernames when inviting members to a group
- store invites under `/groups/{groupId}/invites/{uid}`
- fetch pending invites via collection group query
- display an Invitations card and handle accept/decline

## Testing
- `pnpm lint` *(fails: Unexpected any errors)*
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6864b1b64e248327981ccf56107ed39a