### PR TITLE
Add cleanup workflow for Firebase preview channels

### DIFF
--- a/.github/workflows/firebase-preview-cleanup.yml
+++ b/.github/workflows/firebase-preview-cleanup.yml
@@ -1,0 +1,16 @@
+name: Cleanup Firebase Preview
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_SYNCTIMER_DEV }}'
+      - name: Delete preview channel
+        run: npx firebase-tools@latest hosting:channel:delete pr-${{ github.event.pull_request.number }} --project synctimer-dev-464400 --force


### PR DESCRIPTION
## Summary
- add a workflow that deletes Firebase preview channels when PRs close

## Testing
- `cargo test --manifest-path parser/Cargo.toml --all-features`
- `pnpm --dir web install`
- `pnpm --filter web test`
- `pnpm --filter functions test`


------
https://chatgpt.com/codex/tasks/task_e_6864cf54863c8327880eef5555e88f01