### PR TITLE
Fix lint errors in Cloud Functions

### DIFF
--- a/functions/src/email.ts
+++ b/functions/src/email.ts
@@ -17,10 +17,7 @@ export const initiateEmailChange = functions.https.onCall(
     context: functions.https.CallableContext,
   ) => {
     const uid = context.auth?.uid;
-    const { newEmail, currentPassword } = data as {
-    newEmail?: string;
-    currentPassword?: string;
-  };
+    const { newEmail } = data as { newEmail?: string };
 
     if (!uid) {
       throw new functions.https.HttpsError(

--- a/functions/test/storeParts.test.ts
+++ b/functions/test/storeParts.test.ts
@@ -1,19 +1,26 @@
-jest.mock('firebase-admin', () => ({
+jest.mock("firebase-admin", () => ({
   initializeApp: jest.fn(),
   firestore: jest.fn(() => ({})),
   auth: jest.fn(() => ({})),
 }));
-import { storeParts } from '../src/index';
+import { storeParts } from "../src/index";
+import type { Firestore } from "firebase-admin/firestore";
 
-test('storeParts writes to files collection', async () => {
+test("storeParts writes to files collection", async () => {
   const set = jest.fn().mockResolvedValue(undefined);
-  const add = jest.fn().mockResolvedValue({ id: 'p1' });
+  const add = jest.fn().mockResolvedValue({ id: "p1" });
   const partsCollection = { add };
   const doc = jest.fn(() => ({ set, collection: () => partsCollection }));
   const collection = jest.fn(() => ({ doc }));
-  const db: any = { collection };
-  await storeParts('f1', 'Title', '- id: M1\n  bar: 1\n  instruments:\n  - Violin\n', 'u1', db);
-  expect(collection).toHaveBeenCalledWith('files');
+  const db = { collection } as unknown as Firestore;
+  await storeParts(
+    "f1",
+    "Title",
+    "- id: M1\n  bar: 1\n  instruments:\n  - Violin\n",
+    "u1",
+    db,
+  );
+  expect(collection).toHaveBeenCalledWith("files");
   expect(set).toHaveBeenCalled();
   expect(add).toHaveBeenCalled();
 });

--- a/functions/tsconfig.dev.json
+++ b/functions/tsconfig.dev.json
@@ -1,5 +1,6 @@
 {
   "include": [
-    ".eslintrc.js"
+    ".eslintrc.js",
+    "test/**/*.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- clean up `initiateEmailChange` arguments
- tighten types and line lengths in Firebase functions
- allow ESLint to parse test files
- update test to satisfy ESLint rules

## Testing
- `pnpm --filter functions lint`
- `pnpm --filter functions build`
- `pnpm --filter functions test`


------
https://chatgpt.com/codex/tasks/task_e_6864e19428d883279fbd2fe082620f1d