### PR TITLE
Use Node 18 runtime for functions

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -21,7 +21,7 @@
     }
   },
   "engines": {
-    "node": "22"
+    "node": "18"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/functions/src/email.ts
+++ b/functions/src/email.ts
@@ -1,4 +1,9 @@
-import * as functions from "firebase-functions/v1";
+import {
+  onCall,
+  onRequest,
+  HttpsError,
+  CallableRequest,
+} from "firebase-functions/v2/https";
 import * as admin from "firebase-admin";
 import { randomUUID } from "crypto";
 
@@ -11,25 +16,24 @@ const auth = admin.auth();
  * Creates a verification entry in Firestore which triggers the
  * Trigger Email extension to send a verification email.
  */
-export const initiateEmailChange = functions.https.onCall(
+export const initiateEmailChange = onCall(
   async (
-    data: { newEmail?: string; currentPassword?: string },
-    context: functions.https.CallableContext,
+    request: CallableRequest<{
+      newEmail?: string;
+      currentPassword?: string;
+    }>,
   ) => {
-    const uid = context.auth?.uid;
-    const { newEmail, currentPassword } = data as {
-    newEmail?: string;
-    currentPassword?: string;
-  };
+    const uid = request.auth?.uid;
+    const { newEmail } = request.data as { newEmail?: string };
 
     if (!uid) {
-      throw new functions.https.HttpsError(
+      throw new HttpsError(
         "unauthenticated",
         "Must be signed in."
       );
     }
     if (!newEmail) {
-      throw new functions.https.HttpsError(
+      throw new HttpsError(
         "invalid-argument",
         "newEmail is required."
       );
@@ -57,7 +61,7 @@ export const initiateEmailChange = functions.https.onCall(
  * Called when the user clicks the verification link. Validates the token and
  * updates the user's email if valid.
  */
-export const verifyEmail = functions.https.onRequest(async (req, res) => {
+export const verifyEmail = onRequest(async (req, res) => {
   const { token } = req.query;
   const docRef = db.collection("emailChangeRequests").doc(String(token));
   const doc = await docRef.get();

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,4 +1,9 @@
-import * as functions from "firebase-functions/v1";
+import { onRequest, Request } from "firebase-functions/v2/https";
+import { onSchedule } from "firebase-functions/v2/scheduler";
+import {
+  onDocumentWritten,
+  onDocumentCreated,
+} from "firebase-functions/v2/firestore";
 import * as admin from "firebase-admin";
 import { fetch } from "undici";
 import cors from "cors";
@@ -6,10 +11,10 @@ import { FieldValue } from "firebase-admin/firestore";
 import { randomUUID } from "crypto";
 import YAML from "yaml";
 
+admin.initializeApp();
+
 // Export email change functions
 export * from "./email";
-
-admin.initializeApp();
 const db = admin.firestore();
 
 // default CORS allow-all
@@ -28,10 +33,11 @@ export async function storeParts(
     createdAt: FieldValue.serverTimestamp(),
     ownerUid,
   });
-  const events = YAML.parse(yamlText) as Array<any>;
+  interface EventData { bar?: number; instruments?: string[] }
+  const events = YAML.parse(yamlText) as EventData[];
   const measures = Math.max(
     0,
-    ...events.map((e: any) => e.bar ?? 0),
+    ...events.map((e) => e.bar ?? 0),
   );
   await fileRef.collection("parts").add({
     partName: "Full Score",
@@ -42,11 +48,13 @@ export async function storeParts(
   });
   const instruments = Array.from(
     new Set(
-      events.flatMap((e: any) => (e.instruments ? e.instruments[0] : null)).filter(Boolean),
+      events
+        .flatMap((e) => (e.instruments ? e.instruments[0] : null))
+        .filter(Boolean),
     ),
-  );
+  ) as string[];
   for (const inst of instruments) {
-    const partEvents = events.filter((e: any) =>
+    const partEvents = events.filter((e) =>
       (e.instruments || []).includes(inst),
     );
     const partYaml = YAML.stringify(partEvents);
@@ -60,16 +68,16 @@ export async function storeParts(
   }
 }
 
-function getUidFromHeader(req: functions.https.Request): string | null {
+function getUidFromHeader(req: Request): string | null {
   const auth = req.header("Authorization") || "";
   const m = auth.match(/^Bearer (.+)$/);
   return m ? m[1] : null;
 }
 
-export const parseUpload = functions.https.onRequest((req, res) => {
+export const parseUpload = onRequest((req, res) => {
   corsHandler(req, res, async () => {
     const uid = getUidFromHeader(req);
-    const xml = req.rawBody!;
+    const xml = req.rawBody ?? Buffer.from("");
     let yaml: string;
     let parserRes: Response;
 
@@ -105,7 +113,7 @@ export const parseUpload = functions.https.onRequest((req, res) => {
 
       // 4) return
       res.status(parserRes.ok ? 200 : 500).send(yaml);
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error("parseUpload error:", e);
       const msg = e instanceof Error ? e.message : String(e);
       // log failure
@@ -121,7 +129,7 @@ export const parseUpload = functions.https.onRequest((req, res) => {
   });
 });
 
-export const linkDevice = functions.https.onRequest((req, res) => {
+export const linkDevice = onRequest((req, res) => {
   corsHandler(req, res, async () => {
     const uid = getUidFromHeader(req);
     if (!uid) {
@@ -141,7 +149,7 @@ export const linkDevice = functions.https.onRequest((req, res) => {
           createdAt: FieldValue.serverTimestamp(),
         });
       res.json({ deviceId: doc.id, token });
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error("linkDevice error:", e);
       const msg = e instanceof Error ? e.message : String(e);
       res.status(500).send(msg);
@@ -149,7 +157,7 @@ export const linkDevice = functions.https.onRequest((req, res) => {
   });
 });
 
-export const getLinkToken = functions.https.onRequest((req, res) => {
+export const getLinkToken = onRequest((req, res) => {
   corsHandler(req, res, async () => {
     const uid = getUidFromHeader(req);
     if (!uid) {
@@ -165,7 +173,7 @@ export const getLinkToken = functions.https.onRequest((req, res) => {
         .doc(token)
         .set({ createdAt: FieldValue.serverTimestamp() });
       res.json({ token });
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error("getLinkToken error:", e);
       const msg = e instanceof Error ? e.message : String(e);
       res.status(500).send(msg);
@@ -174,54 +182,62 @@ export const getLinkToken = functions.https.onRequest((req, res) => {
 });
 
 // 1️⃣ Soft-delete flag on group documents
-export const purgeDeletedGroups = functions.pubsub.schedule('every 24 hours').onRun(async () => {
+export const purgeDeletedGroups = onSchedule("every 24 hours", async () => {
   const cutoff = Date.now() - 15 * 24 * 60 * 60 * 1000;
   const snap = await db
-    .collection('groups')
-    .where('isDeleted', '==', true)
-    .where('deletedAt', '<=', admin.firestore.Timestamp.fromMillis(cutoff))
+    .collection("groups")
+    .where("isDeleted", "==", true)
+    .where(
+      "deletedAt",
+      "<=",
+      admin.firestore.Timestamp.fromMillis(cutoff),
+    )
     .get();
-  await Promise.all(snap.docs.map(d => d.ref.delete()));
+  await Promise.all(snap.docs.map((d) => d.ref.delete()));
 });
 
 // Firestore trigger: update memberCount for tags
-export const onTagMemberWrite = functions.firestore
-  .document("tags/{tagId}/members/{uid}")
-  .onWrite(async (
-    change: functions.Change<admin.firestore.DocumentData>,
-    context: functions.EventContext,
-  ) => {
-    const tagId = context.params.tagId;
-    const delta = change.after.exists ? (change.before.exists ? 0 : 1) : -1;
+export const onTagMemberWrite = onDocumentWritten(
+  "tags/{tagId}/members/{uid}",
+  async (event) => {
+    const change = event.data;
+    const tagId = event.params.tagId;
+    const was = change?.before.exists ?? false;
+    const now = change?.after.exists ?? false;
+    const delta = now ? (was ? 0 : 1) : -1;
     if (delta === 0) return null;
     await db.doc(`tags/${tagId}`).update({
       memberCount: FieldValue.increment(delta),
     });
     return null;
-  });
+  },
+);
 
 // Firestore trigger: update memberCount for groups
-export const onGroupMemberWrite = functions.firestore
-  .document("groups/{groupId}/members/{uid}")
-  .onWrite(async (
-    change: functions.Change<admin.firestore.DocumentData>,
-    context: functions.EventContext,
-  ) => {
-    const groupId = context.params.groupId;
-    const delta = change.after.exists ? (change.before.exists ? 0 : 1) : -1;
+export const onGroupMemberWrite = onDocumentWritten(
+  "groups/{groupId}/members/{uid}",
+  async (event) => {
+    const change = event.data;
+    const groupId = event.params.groupId;
+    const was = change?.before.exists ?? false;
+    const now = change?.after.exists ?? false;
+    const delta = now ? (was ? 0 : 1) : -1;
     if (delta === 0) return null;
     await db.doc(`groups/${groupId}`).update({
       memberCount: FieldValue.increment(delta),
     });
     return null;
-  });
+  },
+);
 
 // Firestore trigger: send notifications on new assignments
-export const onAssignmentCreate = functions.firestore
-  .document("assignments/{assignmentId}")
-  .onCreate(async (snap, context) => {
-    const data = snap.data() as any;
-    const id = context.params.assignmentId;
+export const onAssignmentCreate = onDocumentCreated(
+  "assignments/{assignmentId}",
+  async (event) => {
+    const snap = event.data;
+    if (!snap) return null;
+    const data = snap.data() as admin.firestore.DocumentData;
+    const id = event.params.assignmentId;
     for (const rec of data.recipients || []) {
       if (rec.type === "user") {
         await db
@@ -254,7 +270,11 @@ export const onAssignmentCreate = functions.firestore
               .doc(m.id)
               .collection("assignments")
               .doc(id)
-              .set({ ...data, groupId: rec.groupId, assignmentName: rec.assignmentName })
+              .set({
+                ...data,
+                groupId: rec.groupId,
+                assignmentName: rec.assignmentName,
+              })
           )
         );
         await Promise.all(
@@ -275,5 +295,6 @@ export const onAssignmentCreate = functions.firestore
       }
     }
     return null;
-  });
+  },
+);
 

--- a/functions/test/storeParts.test.ts
+++ b/functions/test/storeParts.test.ts
@@ -1,19 +1,26 @@
-jest.mock('firebase-admin', () => ({
+jest.mock("firebase-admin", () => ({
   initializeApp: jest.fn(),
   firestore: jest.fn(() => ({})),
   auth: jest.fn(() => ({})),
 }));
-import { storeParts } from '../src/index';
+import { storeParts } from "../src/index";
+import type { Firestore } from "firebase-admin/firestore";
 
-test('storeParts writes to files collection', async () => {
+test("storeParts writes to files collection", async () => {
   const set = jest.fn().mockResolvedValue(undefined);
-  const add = jest.fn().mockResolvedValue({ id: 'p1' });
+  const add = jest.fn().mockResolvedValue({ id: "p1" });
   const partsCollection = { add };
   const doc = jest.fn(() => ({ set, collection: () => partsCollection }));
   const collection = jest.fn(() => ({ doc }));
-  const db: any = { collection };
-  await storeParts('f1', 'Title', '- id: M1\n  bar: 1\n  instruments:\n  - Violin\n', 'u1', db);
-  expect(collection).toHaveBeenCalledWith('files');
+  const db = { collection } as unknown as Firestore;
+  await storeParts(
+    "f1",
+    "Title",
+    "- id: M1\n  bar: 1\n  instruments:\n  - Violin\n",
+    "u1",
+    db,
+  );
+  expect(collection).toHaveBeenCalledWith("files");
   expect(set).toHaveBeenCalled();
   expect(add).toHaveBeenCalled();
 });

--- a/functions/tsconfig.dev.json
+++ b/functions/tsconfig.dev.json
@@ -1,5 +1,6 @@
 {
   "include": [
-    ".eslintrc.js"
+    ".eslintrc.js",
+    "test/**/*.ts"
   ]
 }

--- a/storage.rules
+++ b/storage.rules
@@ -5,9 +5,10 @@ rules_version = '2';
 //    /databases/(default)/documents/users/$(request.auth.uid)).data.isAdmin;
 service firebase.storage {
   match /b/{bucket}/o {
-    // Users may read and write their own avatar
-    match /avatars/{userId}.jpg {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+    // Users may read and write their own avatar stored at avatars/$(uid).jpg
+    match /avatars/{avatarFile} {
+      allow read, write: if
+        request.auth != null && avatarFile == request.auth.uid + ".jpg";
     }
 
     // Deny all other access by default


### PR DESCRIPTION
## Summary
- set Cloud Functions runtime to Node 18 so deployment no longer sets CPU for gen1 functions
- migrate Cloud Functions code to `firebase-functions/v2`

## Testing
- `pnpm --filter functions lint`
- `pnpm --filter functions build`
- `pnpm --filter functions test`


------
https://chatgpt.com/codex/tasks/task_e_6864e19428d883279fbd2fe082620f1d